### PR TITLE
Fix remaining haplotype-pair non-determinism with deterministic tie-break

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
+++ b/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
@@ -25,7 +25,10 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -181,12 +184,28 @@ public class HLALinkageDisequilibrium {
 			DetectedLinkageFindings findings) {
 		Set<HaplotypePair> linkedPairs = new HaplotypePairSet(new HaplotypePairComparator());
 
-		Set<MultiLocusHaplotype> linkedHaplotypes = new HashSet<MultiLocusHaplotype>();
-		
+		// Was: Set<MultiLocusHaplotype> linkedHaplotypes = new HashSet<>(), added to via a bare
+		// linkedHaplotypes.add(clonedHaplotype). Multiple raw allele combinations enumerated from
+		// the genotype's own ambiguity can independently match the SAME reference disequilibrium
+		// element (they all belong to the same G-group, and reference lookups are G-group/ARS
+		// based, not exact-string), so more than one clonedHaplotype can carry the identical
+		// G-group-level getHaplotypeString() -- that's the "value" -- while differing only in
+		// getFullHaplotypeString() ("fullValue"). Since equals()/hashCode() are (correctly)
+		// based on getHaplotypeString() alone, a plain HashSet.add() silently drops whichever
+		// candidate it encounters second, and which one that is depends on HashSet iteration
+		// order, which is not guaranteed stable across JVM runs -- confirmed via run-twice-diff.
+		// The reference disequilibrium data is loaded with exactly one entry per unique G-group
+		// string (see HLAFrequenciesLoader#loadStandardReferenceData), so any two candidates
+		// tied at the G-group level necessarily matched that identical single reference entry --
+		// the frequency/linkage evidence they carry is the same either way. Keying explicitly by
+		// getHaplotypeString() lets us detect the tie and choose deterministically (smaller
+		// fullValue wins) instead of leaving it to HashSet iteration order.
+		Map<String, MultiLocusHaplotype> linkedHaplotypesByValue = new LinkedHashMap<String, MultiLocusHaplotype>();
+
 		Set<DetectedDisequilibriumElement> detectedDisequilibriumElements = new HashSet<DetectedDisequilibriumElement>();
-		
+
 		MultiLocusHaplotype clonedHaplotype = null;
-				
+
 		for (MultiLocusHaplotype possibleHaplotype : glString.getPossibleHaplotypes(loci)) {
 			List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
 
@@ -194,30 +213,44 @@ public class HLALinkageDisequilibrium {
 
 			for (Locus locus : possibleHaplotype.getLoci()) {
 				if (loci.contains(locus)) {
-					
+
 					hlaElementMap.put(locus, possibleHaplotype.getAlleles(locus));
 				}
 			}
-			
+
 			DisequilibriumElement element = new CoreDisequilibriumElement(hlaElementMap, possibleHaplotype);
 			DetectedDisequilibriumElement detectedElement = null;
-						
+
 			while (shortenedList.contains(element)) {
 				int index = shortenedList.indexOf(element);
 				clonedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(possibleHaplotype.getAlleleMap()), possibleHaplotype.getHaplotypeInstanceMap(), possibleHaplotype.getDrb345Homozygous());
 				detectedElement = new DetectedDisequilibriumElement(shortenedList.get(index));
 				detectedElement.setHaplotype(element.getHaplotype());
 				clonedHaplotype.setLinkage(detectedElement);
-				linkedHaplotypes.add(clonedHaplotype);
+
+				String haplotypeValue = clonedHaplotype.getHaplotypeString();
+				MultiLocusHaplotype existingHaplotype = linkedHaplotypesByValue.get(haplotypeValue);
+
+				if (existingHaplotype == null) {
+					linkedHaplotypesByValue.put(haplotypeValue, clonedHaplotype);
+				}
+				else if (clonedHaplotype.getFullHaplotypeString().compareTo(existingHaplotype.getFullHaplotypeString()) < 0) {
+					LOGGER.fine("Multiple raw allele candidates tie at G-group " + haplotypeValue + ": keeping "
+							+ clonedHaplotype.getFullHaplotypeString() + " over " + existingHaplotype.getFullHaplotypeString());
+					linkedHaplotypesByValue.put(haplotypeValue, clonedHaplotype);
+				}
+
 				detectedDisequilibriumElements.add(detectedElement);
-				
+
 				shortenedList = shortenedList.subList(index + 1, shortenedList.size());
 			}
 		}
-		
+
+		Set<MultiLocusHaplotype> linkedHaplotypes = new LinkedHashSet<MultiLocusHaplotype>(linkedHaplotypesByValue.values());
+
 		findings.addLinkages(detectedDisequilibriumElements);
-		
-		for (Haplotype haplotype1 : linkedHaplotypes) {	
+
+		for (Haplotype haplotype1 : linkedHaplotypes) {
 			for (Haplotype haplotype2 : linkedHaplotypes) {
 				int idx = 0;
 				for (Locus locus : loci) {


### PR DESCRIPTION
## Follow-up to #121

#121 fixed a broken `equals()`/`hashCode()` contract on `Haplotype`/`HaplotypePair`, which stabilized aggregate haplotype-pair counts across repeated runs on identical input (819=819). But a small fraction of samples in a 331-sample real-world batch (Stanford NGS test data) still differed in specific content — a haplotype's G-group-level `value` was stable, but its raw-allele `fullValue` wasn't.

## Root cause

`findLinkedPairs()` in [`HLALinkageDisequilibrium.java`](https://github.com/nmdp-bioinformatics/ImmunogeneticDataTools/blob/master/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java) enumerates candidate haplotypes from a genotype's own recorded ambiguity (e.g. an input listing `B*52:07` and `B*52:01:01:01/B*52:01:01:02` as alternate possibilities at one locus). Reference-table matching is G-group/ARS-based, not exact-string (`DisequilibriumElement#equals` → `GLStringUtilities#checkAntigenRecognitionSite`), so multiple such candidates can independently match the *same* reference disequilibrium element — the reference data has exactly one entry per unique G-group string (`HLAFrequenciesLoader#loadStandardReferenceData` merges same-string rows across races into one element), so this is guaranteed to carry identical frequency/linkage evidence either way. The only open question was which raw allele string to display.

The code tracked these candidates in a plain `HashSet<MultiLocusHaplotype>` via `linkedHaplotypes.add(clonedHaplotype)`. Since `Haplotype#equals()`/`hashCode()` are (correctly, per #121) based on the G-group-level `getHaplotypeString()`, two tied candidates collide in the set, and `HashSet.add()` silently drops whichever arrives second — with no defined winner, since `HashSet` iteration order isn't guaranteed stable across JVM runs.

## Fix

Track candidates in a `Map<String, MultiLocusHaplotype>` keyed by `getHaplotypeString()`. On a collision, explicitly compare `getFullHaplotypeString()` and keep the lexicographically smaller one — deterministic regardless of arrival order (min-comparison is commutative), so no changes were needed to the (also-`HashSet`-backed) upstream candidate enumeration in `constructPossibleHaplotypes()`. A `LOGGER.fine()` call records when a tie is broken, for visibility without changing the report schema.

## Verification

- `ld-validation` unit tests: 32/32 pass.
- Ran the CLI twice against the same 331-sample real-world file that previously showed divergence between runs — `summary.xml` is now byte-for-byte identical across runs (confirmed via md5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)