### PR TITLE
Migrate commons-lang 2.6 to commons-lang3 3.18.0 (CVE-2025-48924)

### DIFF
--- a/ld-validation/pom.xml
+++ b/ld-validation/pom.xml
@@ -78,10 +78,15 @@
       <artifactId>jaxb-runtime</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!-- commons-lang 2.x (was 2.6) is permanently unpatched for CVE-2025-48924 / GHSA-j288-q9x7-2f5v
+         (StackOverflowError from uncontrolled recursion in ClassUtils.getClass() on very long
+         inputs); the fix only exists on the commons-lang3 line (3.18.0+). Usage here is a
+         single StringUtils.countMatches() call in GLStringUtilities, which has an identical
+         signature on commons-lang3, so this is a straight dependency + import swap. -->
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.18.0</version>
     </dependency>
   </dependencies>
 

--- a/ld-validation/src/main/java/org/dash/valid/gl/GLStringUtilities.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/GLStringUtilities.java
@@ -44,7 +44,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.dash.valid.LinkagesLoader;
 import org.dash.valid.Locus;


### PR DESCRIPTION
Closes the dependabot alert for [GHSA-j288-q9x7-2f5v / CVE-2025-48924](https://github.com/nmdp-bioinformatics/ImmunogeneticDataTools/security/dependabot/27): `ClassUtils.getClass(...)` can throw `StackOverflowError` from uncontrolled recursion on very long inputs.

No fix exists on the `commons-lang` 2.x line — the GHSA's own patched-version data confirms it's null there. Only `commons-lang3` 3.18.0+ is patched, so this needed a real dependency swap rather than a version bump.

Actual usage turned out to be minimal: exactly one call site in the whole codebase — `StringUtils.countMatches()` in `GLStringUtilities.java` — which has an identical signature on `commons-lang3`. Swapped the `ld-validation/pom.xml` dependency (`commons-lang:commons-lang:2.6` → `org.apache.commons:commons-lang3:3.18.0`) and the one import.

## Verification

`ld-validation` unit tests: 32/32 pass, including `GLStringUtilitiesTest` (15/15), which exercises the `countMatches()` call path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)