### PR TITLE
Fix remaining haplotype-pair non-determinism: broken equals()/hashCode() in DetectedDisequilibriumElement

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
+++ b/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
@@ -24,7 +24,6 @@ package org.dash.valid;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -202,8 +201,6 @@ public class HLALinkageDisequilibrium {
 		// fullValue wins) instead of leaving it to HashSet iteration order.
 		Map<String, MultiLocusHaplotype> linkedHaplotypesByValue = new LinkedHashMap<String, MultiLocusHaplotype>();
 
-		Set<DetectedDisequilibriumElement> detectedDisequilibriumElements = new HashSet<DetectedDisequilibriumElement>();
-
 		MultiLocusHaplotype clonedHaplotype = null;
 
 		for (MultiLocusHaplotype possibleHaplotype : glString.getPossibleHaplotypes(loci)) {
@@ -240,13 +237,36 @@ public class HLALinkageDisequilibrium {
 					linkedHaplotypesByValue.put(haplotypeValue, clonedHaplotype);
 				}
 
-				detectedDisequilibriumElements.add(detectedElement);
-
 				shortenedList = shortenedList.subList(index + 1, shortenedList.size());
 			}
 		}
 
 		Set<MultiLocusHaplotype> linkedHaplotypes = new LinkedHashSet<MultiLocusHaplotype>(linkedHaplotypesByValue.values());
+
+		// Was: a separate Set<DetectedDisequilibriumElement> detectedDisequilibriumElements =
+		// new HashSet<>(), added to unconditionally inside the while loop above (once per
+		// reference-row match, so once per tied candidate too), then merged into
+		// findings.linkages -- a LinkageElementsSet (TreeSet) ordered by
+		// DisequilibriumElementComparator, whose compare() starts with
+		// DetectedDisequilibriumElement#equals(), which is true for any two matches of the
+		// same reference row regardless of which raw-allele candidate matched it. That made
+		// the TreeSet treat tied candidates as duplicates and silently keep whichever the
+		// *source* HashSet happened to iterate first -- but DetectedDisequilibriumElement
+		// overrides equals() without overriding hashCode(), so that HashSet's iteration order
+		// was governed by default (identity-based) hashCode(), which is JVM-launch-random.
+		// Confirmed via instrumented tracing: the in-memory linkedHaplotypesByValue tie-break
+		// above was already fully deterministic and identical across JVM launches, yet the
+		// final report still varied -- because this separate, parallel structure was never
+		// touched by that fix and re-introduced the same class of bug one level up. Deriving
+		// the linkages directly from linkedHaplotypesByValue's already-deterministic winners
+		// (each winning clonedHaplotype's own linkage is exactly the DetectedDisequilibriumElement
+		// that should represent its reference row) sidesteps the broken equals()/hashCode()
+		// pair entirely, and keeps the <linkage> report section consistent with which
+		// candidate's fullValue is reported as the haplotype pair.
+		Set<DetectedDisequilibriumElement> detectedDisequilibriumElements = new LinkedHashSet<DetectedDisequilibriumElement>();
+		for (MultiLocusHaplotype winner : linkedHaplotypes) {
+			detectedDisequilibriumElements.add(winner.getLinkage());
+		}
 
 		findings.addLinkages(detectedDisequilibriumElements);
 

--- a/ld-validation/src/test/java/org/dash/LinkageDisequilibriumAnalyzerTest.java
+++ b/ld-validation/src/test/java/org/dash/LinkageDisequilibriumAnalyzerTest.java
@@ -21,7 +21,9 @@
 */
 package org.dash;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -36,6 +38,9 @@ import org.dash.valid.freq.Frequencies;
 import org.dash.valid.gl.GLStringUtilities;
 import org.dash.valid.gl.LinkageDisequilibriumGenotypeList;
 import org.dash.valid.gl.haplo.Haplotype;
+import org.dash.valid.gl.haplo.HaplotypePair;
+import org.dash.valid.report.DetectedDisequilibriumElement;
+import org.dash.valid.report.DetectedLinkageFindings;
 import org.junit.jupiter.api.Test;
 
 public class LinkageDisequilibriumAnalyzerTest {	
@@ -75,12 +80,83 @@ public class LinkageDisequilibriumAnalyzerTest {
 	}
 	
 	@Test
-	public void testLinkageReportingInlineGLString() throws IOException {				
+	public void testLinkageReportingInlineGLString() throws IOException {
 		String fullyQualified = GLStringUtilities.fullyQualifyGLString("HLA-A*11:01:01+HLA-A*24:02:01:01/HLA-A*24:02:01:02L/HLA-A*24:02:01:03^HLA-B*18:01:01:01/HLA-B*18:01:01:02/HLA-B*18:51+HLA-B*53:01:01^HLA-C*04:01:01:01/HLA-C*04:01:01:02/HLA-C*04:01:01:03/HLA-C*04:01:01:04/HLA-C*04:01:01:05/HLA-C*04:20/HLA-C*04:117+HLA-C*12:03:01:01/HLA-C*12:03:01:02/HLA-C*12:34^HLA-DPA1*01:03:01:01/HLA-DPA1*01:03:01:02/HLA-DPA1*01:03:01:03/HLA-DPA1*01:03:01:04/HLA-DPA1*01:03:01:05+HLA-DPA1*02:01:01^HLA-DPB1*02:01:02+HLA-DPB1*09:01^HLA-DQA1*01:02:01:01/HLA-DQA1*01:02:01:02/HLA-DQA1*01:02:01:03/HLA-DQA1*01:02:01:04/HLA-DQA1*01:11+HLA-DQA1*03:01:01^HLA-DQB1*03:05:01+HLA-DQB1*06:09^HLA-DRB1*11:04:01+HLA-DRB1*13:02:01^HLA-DRB3*02:02:01:01/HLA-DRB3*02:02:01:02+HLA-DRB3*03:01:01");
-		
+
 		LinkageDisequilibriumGenotypeList glString = new LinkageDisequilibriumGenotypeList("fullyQualified", fullyQualified);
 		Sample sample = LinkageDisequilibriumAnalyzer.detectLinkages(glString);
-				
-		assertNotNull(sample);	
+
+		assertNotNull(sample);
+	}
+
+	// Regression test for the non-determinism found while verifying #124 (perf fix): multiple
+	// raw allele candidates enumerated from this genotype's own "|" ambiguity at HLA-B
+	// (52:01:01:01/52:01:01:02 vs 52:07, both under G-group B*52:01g) tie against the same
+	// reference row for HLA-C*12:02~HLA-B*52:01g. findLinkedPairs()'s own tie-break (fixed in
+	// #122) picks the deterministic winner correctly and consistently -- but a separate,
+	// parallel structure (detectedDisequilibriumElements -> findings.linkages, a TreeSet keyed
+	// by a comparator that treats any two matches of the same reference row as equal) relied on
+	// DetectedDisequilibriumElement's default (identity-based) hashCode(), since it overrides
+	// equals() without overriding hashCode() -- a genuine contract violation. That meant the
+	// <linkage> report section could report a *different* fullValue for this same G-group than
+	// the <haplo-pair> section reported, and which one varied across separate JVM launches
+	// (confirmed via 8 repeated CLI runs on real data landing in one of two states). Both
+	// sections must agree, deterministically, in every run -- this only checks one JVM's worth,
+	// since default hashCode() is stable within a single process, but it does lock in the
+	// invariant the bug actually violated.
+	@Test
+	public void testTiedGGroupCandidateReportedConsistently() throws IOException, ReflectiveOperationException {
+		// LinkagesLoader/HLAFrequenciesLoader are process-wide singletons whose getInstance()
+		// is a no-op once already initialized -- and other tests in this same forked JVM
+		// initialize them first (this file's own class-level "TODO: Write tests" on
+		// LinkagesLoader is a pre-existing gap, not introduced here). Reset both via
+		// reflection so this test's expected reference data is actually the data in effect,
+		// regardless of what ran before it.
+		resetSingleton(LinkagesLoader.class);
+		resetSingleton(org.dash.valid.freq.HLAFrequenciesLoader.class);
+
+		System.setProperty(Frequencies.FREQUENCIES_PROPERTY, Frequencies.NMDP_2007_STD.getShortName());
+		LinkagesLoader.getInstance(Linkages.lookup(Locus.C_B_LOCI));
+
+		String fullyQualified = GLStringUtilities.fullyQualifyGLString(
+				"HLA-B*52:01:01:01/52:01:01:02+HLA-B*56:01:01/56:26|52:07+HLA-B*56:26^HLA-C*01:02:01+HLA-C*12:02:02");
+		LinkageDisequilibriumGenotypeList glString = new LinkageDisequilibriumGenotypeList("tiedGGroup", fullyQualified);
+
+		Sample sample = LinkageDisequilibriumAnalyzer.detectLinkages(glString);
+		DetectedLinkageFindings findings = sample.getFindings();
+
+		String tiedValue = "HLA-C*12:02~HLA-B*52:01g";
+		// The two candidates the genotype's own ambiguity produces for this G-group; the
+		// lexicographically smaller one is the deterministic winner (see #122).
+		String expectedFullValue = "HLA-C*12:02:02~HLA-B*52:01:01:01/HLA-B*52:01:01:02";
+
+		DetectedDisequilibriumElement matchingLinkage = null;
+		for (DetectedDisequilibriumElement linkage : findings.getLinkages()) {
+			if (tiedValue.equals(linkage.getHaplotype().getHaplotypeString())) {
+				matchingLinkage = linkage;
+				break;
+			}
+		}
+		assertNotNull(matchingLinkage, "Expected a <linkage> entry for " + tiedValue);
+		assertEquals(expectedFullValue, matchingLinkage.getHaplotype().getFullHaplotypeString(),
+				"findings.getLinkages() reported an unexpected fullValue for the tied G-group");
+
+		boolean foundMatchingPairHaplotype = false;
+		for (HaplotypePair pair : findings.getLinkedPairs()) {
+			for (Haplotype haplotype : pair.getHaplotypes()) {
+				if (tiedValue.equals(haplotype.getHaplotypeString())) {
+					assertEquals(expectedFullValue, haplotype.getFullHaplotypeString(),
+							"findings.getLinkedPairs() disagreed with findings.getLinkages() on the tied G-group's fullValue");
+					foundMatchingPairHaplotype = true;
+				}
+			}
+		}
+		assertTrue(foundMatchingPairHaplotype, "Expected a haplotype pair referencing " + tiedValue);
+	}
+
+	private static void resetSingleton(Class<?> clazz) throws ReflectiveOperationException {
+		java.lang.reflect.Field instanceField = clazz.getDeclaredField("instance");
+		instanceField.setAccessible(true);
+		instanceField.set(null, null);
 	}
 }


### PR DESCRIPTION
## Background

While verifying #124 (a behaviorally-equivalent perf refactor of `fieldLevelComparison()`/`convertToProteinLevel()`), I found that the **unmodified #122+#123 code itself** produces different `summary.xml` output across separate launches on identical input — 6 repeated CLI runs landed in one of two states (5:1). That means #122's "full determinism achieved" conclusion was premature; the mechanism it fixed wasn't the whole story.

## Root cause

Traced with the same instrumented approach as #122 — logging `Linkages` iteration order, candidate visitation order, and tie-break decisions, filtered to the affected samples, across matched pairs of runs landing in each observed state.

`findLinkedPairs()`'s own tie-break (#122's fix) was confirmed byte-for-byte identical between the two modes, all the way through building the final `HaplotypePair` objects. The bug isn't there.

The actual mechanism: `DetectedDisequilibriumElement` overrides `equals()` (true for any two matches of the *same reference row*, regardless of which raw-allele candidate matched it) without overriding `hashCode()` — the same equals()/hashCode() contract violation as the original #13 bug, in a different, parallel class that #122 never touched. `findLinkedPairs()` added every `DetectedDisequilibriumElement` created (once per tied candidate) into a plain `HashSet`, which the broken contract left essentially undeduplicated (default identity hashCodes practically never collide) and in JVM-launch-random order. That set then merged into `DetectedLinkageFindings.linkages` — a `TreeSet` ordered by `DisequilibriumElementComparator`, whose `compare()` starts with `equals()` — so it silently kept whichever tied candidate the source `HashSet` happened to iterate first, independent of (and inconsistent with) which candidate #122's own correct tie-break had already picked for the corresponding haplotype pair.

## Fix

Derive the linkages set directly from `linkedHaplotypesByValue`'s already-deterministic winners (each winning haplotype's own `.getLinkage()` *is* the `DetectedDisequilibriumElement` that should represent its reference row), instead of accumulating and deduplicating them separately. This sidesteps the broken equals()/hashCode() pair entirely, and guarantees the `<linkage>` report section agrees with the `<haplo-pair>` section on which candidate's fullValue is reported.

## Tests

Added `testTiedGGroupCandidateReportedConsistently` — a real tied-G-group genotype, asserting the `<linkage>` and `<haplo-pair>` sections report the same fullValue. Verified it fails reliably (6/6 runs) against the pre-fix code with a clear assertion message, and passes reliably (checked across repeated full-suite runs, order-independent of other tests' singleton state) against the fix.

## Verification

- `ld-validation` unit tests: 33/33 pass (including the new regression test).
- Ran the CLI 6 times against the same 331-sample real-world file that previously alternated between two states — `summary.xml` is now byte-for-byte identical (md5 match) across all 6 runs.

## Scoping note

The other `hasLinkageDisequilibrium()` overload (used for already-phased genotypes, via `enrichHaplotype()`) has its own, separate call into `findings.addLinkage()` and was not confirmed to exhibit this bug — not touched here, left as a lower-priority follow-up if it's ever observed to be affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)