### PR TITLE
Add JaCoCo coverage reporting for ld-validation (no gate)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,15 @@ jobs:
       - run:
           name: Build
           command: mvn -B -DskipTests clean package
-      # Then run your tests!
+      # Then run your tests! verify (not just test) so ld-validation's jacoco:report
+      # execution -- bound to the verify phase -- actually runs and produces a coverage
+      # report; reporting only, doesn't fail the build on a coverage number.
       - run:
           name: Test
-          command: mvn test
+          command: mvn verify
+      - store_artifacts:
+          path: ld-validation/target/site/jacoco
+          destination: coverage/ld-validation
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/ld-validation/pom.xml
+++ b/ld-validation/pom.xml
@@ -116,6 +116,48 @@
         <artifactId>maven-project-info-reports-plugin</artifactId>
         <version>3.3.0</version>
       </plugin>
+      <!-- The root pom's surefire pluginManagement hardcodes argLine to "-Xmx4G", which
+           overwrites (rather than chains with) the -javaagent flag jacoco:prepare-agent
+           injects via the argLine property below; without this override, jacoco silently
+           collects no execution data and report skips with "missing execution data file".
+           Re-declaring surefire here, scoped to just this module, to chain the two instead of
+           touching the root pom's shared config (which every other module also inherits). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>@{argLine} -Xmx4G</argLine>
+        </configuration>
+      </plugin>
+      <!-- Coverage reporting only, not a threshold/gate. Scoped to this module since it's the
+           one with real test infrastructure; ld-tools has 2 test files and ld-service has none,
+           so instrumenting them wouldn't measure anything meaningful yet. prepare-agent wires
+           the runtime agent into surefire's argLine; report (bound to verify, which runs after
+           test) turns the collected exec data into target/site/jacoco/index.html. CI stores that
+           as a build artifact, see .circleci/config.yml, so coverage is visible without
+           failing the build on a number nobody's agreed on yet (ld-service in particular has no
+           test coverage at all right now; a hard gate today would either fail immediately or
+           need exclusions carved out before this is even useful). -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.12</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Reporting only — this does not fail the build on a coverage number. Scoped to `ld-validation` since that's the module with real test infrastructure; `ld-tools` has 2 test files and `ld-service` has none, so instrumenting them wouldn't measure anything meaningful yet, and `ld-service` in particular has zero existing coverage — a hard threshold gate today would either fail immediately or need exclusions carved out before it's even useful.

## What's added

- `jacoco-maven-plugin` in `ld-validation/pom.xml`: `prepare-agent` (injects the `-javaagent` flag via the `argLine` property) and `report` (bound to the `verify` phase, so it runs after tests) goals.
- Hit the standard jacoco+surefire integration gotcha along the way: the root pom's surefire `pluginManagement` hardcodes `argLine` to a literal `-Xmx4G`, which overwrites rather than chains with jacoco's injected flag — jacoco silently collected no execution data until surefire was re-declared here (scoped to just this module) with `argLine="@{argLine} -Xmx4G"` to chain them instead.
- CI now runs `mvn verify` instead of `mvn test` (`verify` is the first phase that runs after `test` in the standard lifecycle, so `jacoco:report` actually gets a chance to run) and stores `ld-validation/target/site/jacoco` as a build artifact under `coverage/ld-validation`, so the report is visible in the CircleCI UI without gating anything.

## Verification

- `ld-validation` unit tests: 42/42 pass under the new surefire config.
- Full reactor `mvn verify` (matching the new CI command exactly) succeeds across all three modules.
- Coverage report generates real, non-trivial data — 80% instruction coverage overall at HEAD, broken down per-package in `target/site/jacoco/index.html` — confirming the report isn't just an empty/broken artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)