### PR TITLE
Release v1.0.0: bump project version from 0.0.1-SNAPSHOT

### DIFF
--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -26,11 +26,11 @@
   <parent>
     <groupId>org.nmdp.validation</groupId>
     <artifactId>ld-multimodule</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>ld-service</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0</version>
   <name>ld-service</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/ld-tools/pom.xml
+++ b/ld-tools/pom.xml
@@ -26,10 +26,10 @@
   <parent>
     <groupId>org.nmdp.validation</groupId>
     <artifactId>ld-multimodule</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>ld-tools</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0</version>
   <name>ld-tools</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/ld-validation/pom.xml
+++ b/ld-validation/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.nmdp.validation</groupId>
     <artifactId>ld-multimodule</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>ld-validation</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   </parent>
   <groupId>org.nmdp.validation</groupId>
   <artifactId>ld-multimodule</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0</version>
   
   <scm>
     <url>https://github.com/mpresteg/ImmunogeneticDataTools</url>


### PR DESCRIPTION
## What

Bumps the four reactor poms' own `<version>`/`<parent><version>` from
`0.0.1-SNAPSHOT` to `1.0.0`, in preparation for tagging and cutting the
`v1.0.0` release.

## Why now, why 1.0.0

This project has stayed on `0.0.1-SNAPSHOT` in the pom for its entire
~10-year history — every prior release (23 tags, most recently
`v0.9.2` in Feb 2023) was tag-only, with the pom version never bumped.

That convention has a real, user-visible bug: the built release
binaries have always been labeled `0.0.1-SNAPSHOT` in their filenames
regardless of which tag they were actually released under. Confirmed
against `v0.9.2`'s actual GitHub release assets
(`ld-tools-0.0.1-SNAPSHOT-bin.zip` etc.) — misleading regardless of
the real version, and actively wrong for anyone grabbing the jar
outside of the GitHub releases page context.

`v1.0.0` (not a smaller bump) given the scale of what has landed since
`v0.9.2`: Spring Boot 2->3, Java 17->25, a full javax->jakarta
migration, and several real correctness fixes to the core linkage
disequilibrium detection algorithm. This has been a real, working,
cited tool (Osoegawa et al. 2015) for a decade despite never leaving
pre-1.0.

## Scope

Only the four poms' own version fields changed — cross-module
dependencies already reference `${project.version}`, and
`ld-service`'s generated `ld-client` (independently versioned OpenAPI
client) is untouched.

## Verification

Full reactor `mvn clean verify` passes (50 tests). Confirmed the
actual bug is fixed: `ld-tools/target` now produces
`ld-tools-1.0.0-bin.{zip,tar.gz,tar.bz2}`, `ld-tools-1.0.0.jar`,
`ld-tools_1.0.0_all.deb` instead of the old
`...0.0.1-SNAPSHOT...`-labeled names.

## Next steps (not in this PR)

Per the release workflow, once this merges: tag the merged commit
`v1.0.0`, build final binaries from that tag, write categorized
release notes, and `gh release create` on this repo (releases going
forward come from upstream only, not the fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
