### PR TITLE
Batch: browser UI docs, and a real performance/correctness investigation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,35 @@ if a test's expected allele/G-group counts look wrong after a new IMGT/HLA relea
 the `hladb` Maven property and the `org.dash.hladb` system property before assuming it's
 a real regression.
 
+### Running `ld-service` for local iteration
+
+`ld-service/README.md`'s "Running it" only documents the packaged jar, which is what an
+end user of the service actually wants. For a faster edit-run loop while working on
+`ld-service` itself, `spring-boot:run` skips the packaging step:
+
+```
+mvn -f ld-service/pom.xml spring-boot:run
+```
+
+`-f` (point at this module's own `pom.xml` directly) matters here, not just style: the
+more obvious `mvn -pl ld-service -am spring-boot:run` looks equivalent but fails with
+"Unable to find a suitable main class" — the root `pom.xml` (artifactId `ld-multimodule`)
+itself inherits from `spring-boot-starter-parent`, so a bare `plugin:goal` invocation (as
+opposed to a lifecycle phase) tries to run `spring-boot:run` against every project
+`-pl ld-service -am` pulls into the reactor, including that root aggregator — which has
+no main class and fails before the reactor ever reaches `ld-service`. `-f` builds only
+this module, sidestepping the aggregator entirely — which means `ld-validation` needs to
+already be installed to your local repo (`mvn install` from the root at least once; plain
+`mvn clean package` doesn't put it there), since `-f` doesn't build it alongside `ld-service`
+in the same reactor pass the way `-am` would.
+
+Don't use `spring-boot:run` to judge real performance, though — it launches with
+`-XX:TieredStopAtLevel=1` (Spring Boot Maven Plugin's own dev-mode default, not anything
+configured here), which disables the JVM's C2 JIT compiler to speed up startup for a quick
+edit-run loop, at a real cost to throughput on long-running CPU-bound work (e.g. parsing a
+large custom frequency file — see `ld-service/README.md`'s note on `LOADING_REFERENCE_DATA`
+taking minutes for real reference data). Use the packaged jar for that instead.
+
 ## Branch / PR workflow
 
 - One branch per unit of work, targeted at this repo's `master`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,19 @@ The results of the software should be used for supporting the evidence, but not 
 *Future Goals:*
 
  * Host publicly
- 
+
+#### Modules
+
+This repository is a multi-module Maven project (the three modules the root `pom.xml`
+actually builds):
+
+* **[`ld-validation`](ld-validation/README.md)** — the core detection library. Has no CLI or API of its own; both of the below are built on top of it.
+* **[`ld-tools`](ld-tools/README.md)** — the command-line tools described in the rest of this README (`analyze-gl-strings`, `normalize-frequency-file`, `synthetic-gl-string-generator`).
+* **[`ld-service`](ld-service/README.md)** — a REST API and browser UI wrapping the same detection library, for anyone who'd rather not use the command line. Includes an async job API (large inputs and custom reference-data uploads can take minutes to process) and a plain HTML/CSS/JS browser UI for `analyze-gl-strings` — see its README for the API, the UI, and how to run it. Its `ld-service/ld-client` subdirectory is a separate, auto-generated Java API client (not part of this Maven reactor; regenerated from the spec rather than hand-edited).
+
+The rest of this README covers the original `ld-tools` command-line workflow; see the
+[`ld-service` README](ld-service/README.md) for the REST API and browser UI instead.
+
 #### Using the software:
 As of release .7, the ability to download the software package and make use of command line tools is available.
 

--- a/ld-service/README.md
+++ b/ld-service/README.md
@@ -65,6 +65,26 @@ Interactive docs (springdoc-openapi) are served once the app is running:
 - Swagger UI: `http://localhost:8080/swagger-ui/index.html`
 - OpenAPI JSON: `http://localhost:8080/v3/api-docs`
 
+## Browser UI
+
+Once the app is running, open **`http://localhost:8080/`** for a browser UI covering the
+same `analyze-gl-strings` workflow as the CLI and the `/genotypes/file` API above — it's
+served as a static resource (`src/main/resources/static`) by this same Spring Boot app, no
+separate setup. It supports:
+
+- Pasting GL strings directly, or uploading a batch file — either way submits through the
+  same async job API described above, so even a single pasted genotype gets progress
+  tracking rather than a blocking request
+- Selecting `hladbVersion`/`frequencySet`, or uploading your own `frequencyFiles`/`allelesFile`
+- Live progress while the job runs (an indeterminate bar while reference data loads, a real
+  percentage during genotype analysis)
+- Results per sample: an anomaly/clean badge, warnings, haplotype-pair frequency tables, and
+  the same four report texts the CLI writes to `*.log`/`.csv` files, each shown collapsed
+- A "Download reports" button that assembles those report texts into one file
+
+v1 covers `analyze-gl-strings` only — `normalize-frequency-file` and
+`synthetic-gl-string-generator` remain CLI-only for now.
+
 ## Running it
 
 ```

--- a/ld-service/README.md
+++ b/ld-service/README.md
@@ -87,38 +87,12 @@ v1 covers `analyze-gl-strings` only — `normalize-frequency-file` and
 
 ## Running it
 
-From the repo root, once `ld-validation` has been installed to your local Maven repo at
-least once (`mvn install` from the root — plain `mvn clean package` doesn't put it there):
-
-```
-mvn -f ld-service/pom.xml spring-boot:run
-```
-
-`-f` (point at this module's own `pom.xml` directly) matters here, not just style: the more
-obvious `mvn -pl ld-service -am spring-boot:run` looks equivalent but fails with "Unable to
-find a suitable main class" — the root `pom.xml` (artifactId `ld-multimodule`) itself
-inherits from `spring-boot-starter-parent`, so a bare `plugin:goal` invocation (as opposed to
-a lifecycle phase) tries to run `spring-boot:run` against every project `-pl ld-service -am`
-pulls into the reactor, including that root aggregator — which has no main class and fails
-before the reactor ever reaches `ld-service`. `-f` builds only this module, sidestepping the
-aggregator entirely (hence needing `ld-validation` pre-installed rather than built alongside
-it in the same reactor pass, the way `-am` would).
-
-Or build the jar and run it directly (this form is unaffected — `package` is a lifecycle
-phase, not a bare goal, so it isn't subject to the same issue):
+Build the jar and run it directly:
 
 ```
 mvn -pl ld-service -am package
 java -jar ld-service/target/ld-service-1.0.0.jar
 ```
-
-**Prefer the jar over `spring-boot:run` for anything performance-sensitive** — e.g. testing
-against a large custom frequency file, where `LOADING_REFERENCE_DATA` can genuinely take
-minutes (see above). `spring-boot:run` launches with `-XX:TieredStopAtLevel=1`
-(Spring Boot Maven Plugin's own dev-mode default, not anything configured here) — it
-disables the JVM's C2 JIT compiler to speed up startup for a quick edit-run loop, at a real
-cost to throughput on exactly this kind of long-running, CPU-bound parse. The jar runs with
-the JVM's normal full tiered compilation instead.
 
 `docker-compose.yml` here also runs a pre-built image (`mpresteg/hlahapv:latest`) on port
 8080, if you don't want to build locally.

--- a/ld-service/README.md
+++ b/ld-service/README.md
@@ -87,11 +87,25 @@ v1 covers `analyze-gl-strings` only — `normalize-frequency-file` and
 
 ## Running it
 
+From the repo root, once `ld-validation` has been installed to your local Maven repo at
+least once (`mvn install` from the root — plain `mvn clean package` doesn't put it there):
+
 ```
-mvn -pl ld-service -am spring-boot:run
+mvn -f ld-service/pom.xml spring-boot:run
 ```
 
-or build the jar and run it directly:
+`-f` (point at this module's own `pom.xml` directly) matters here, not just style: the more
+obvious `mvn -pl ld-service -am spring-boot:run` looks equivalent but fails with "Unable to
+find a suitable main class" — the root `pom.xml` (artifactId `ld-multimodule`) itself
+inherits from `spring-boot-starter-parent`, so a bare `plugin:goal` invocation (as opposed to
+a lifecycle phase) tries to run `spring-boot:run` against every project `-pl ld-service -am`
+pulls into the reactor, including that root aggregator — which has no main class and fails
+before the reactor ever reaches `ld-service`. `-f` builds only this module, sidestepping the
+aggregator entirely (hence needing `ld-validation` pre-installed rather than built alongside
+it in the same reactor pass, the way `-am` would).
+
+Or build the jar and run it directly (this form is unaffected — `package` is a lifecycle
+phase, not a bare goal, so it isn't subject to the same issue):
 
 ```
 mvn -pl ld-service -am package

--- a/ld-service/README.md
+++ b/ld-service/README.md
@@ -112,6 +112,14 @@ mvn -pl ld-service -am package
 java -jar ld-service/target/ld-service-1.0.0.jar
 ```
 
+**Prefer the jar over `spring-boot:run` for anything performance-sensitive** — e.g. testing
+against a large custom frequency file, where `LOADING_REFERENCE_DATA` can genuinely take
+minutes (see above). `spring-boot:run` launches with `-XX:TieredStopAtLevel=1`
+(Spring Boot Maven Plugin's own dev-mode default, not anything configured here) — it
+disables the JVM's C2 JIT compiler to speed up startup for a quick edit-run loop, at a real
+cost to throughput on exactly this kind of long-running, CPU-bound parse. The jar runs with
+the JVM's normal full tiered compilation instead.
+
 `docker-compose.yml` here also runs a pre-built image (`mpresteg/hlahapv:latest`) on port
 8080, if you don't want to build locally.
 

--- a/ld-validation/src/main/java/org/dash/valid/DisequilibriumElementIndex.java
+++ b/ld-validation/src/main/java/org/dash/valid/DisequilibriumElementIndex.java
@@ -1,0 +1,300 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.dash.valid.ars.AntigenRecognitionSiteLoader;
+import org.dash.valid.gl.GLStringConstants;
+import org.dash.valid.gl.GLStringUtilities;
+
+/**
+ * Accelerates {@link DisequilibriumElement#equals(Object)} lookups against a (potentially very
+ * large, e.g. 900K+ rows for a real custom-uploaded frequency file) reference list, without
+ * changing what counts as a match.
+ * <p>
+ * {@code equals()}'s notion of "match" per locus is the OR of two independent, non-exact-string
+ * comparisons -- {@link GLStringUtilities#fieldLevelComparison} (colon-field prefix truncation,
+ * to whichever side has fewer fields) and {@link GLStringUtilities#checkAntigenRecognitionSite}
+ * (ARS/G-group membership) -- so a plain {@code Map<String, DisequilibriumElement>} keyed by
+ * allele string would silently miss real matches. This class instead builds, per locus:
+ * <ul>
+ * <li>a field-prefix index covering every reference row at every truncation depth its own
+ *     allele string supports, so a query allele of any length finds every row whose comparison
+ *     (at whichever length is shorter) would agree; and</li>
+ * <li>an ARS-code index, inverting {@link AntigenRecognitionSiteLoader}'s existing map against
+ *     the reference rows actually present.</li>
+ * </ul>
+ * A query's per-locus candidate sets (built from these indexes) are intersected across the
+ * query's own locus set, exactly mirroring {@code equals()}'s per-locus AND -- including the
+ * DRB345 homozygous dash/{@code NNNN} special case, precomputed once since it only ever depends
+ * on the reference data, not the query. The surviving candidates are then confirmed with the
+ * real {@code equals()} before being returned, so an indexing mistake can only cost speed, never
+ * silently produce a wrong match.
+ * <p>
+ * Built once per distinct reference list (identity-cached, not equals()/hashCode()-cached --
+ * {@code DisequilibriumElement} intentionally has no {@code hashCode()}, see its {@code equals()}
+ * javadoc) and reused across every candidate haplotype and every genotype checked against that
+ * same list within a run. {@link org.dash.valid.freq.HLAFrequenciesLoader#reset()} always
+ * installs a brand new list rather than mutating the old one in place, so a plain identity cache
+ * here needs no explicit invalidation -- a reset simply makes the old cache entry unreachable.
+ */
+class DisequilibriumElementIndex {
+	private static final Logger LOGGER = Logger.getLogger(DisequilibriumElementIndex.class.getName());
+
+	private static final Map<List<DisequilibriumElement>, DisequilibriumElementIndex> CACHE =
+			new IdentityHashMap<List<DisequilibriumElement>, DisequilibriumElementIndex>();
+
+	private final List<DisequilibriumElement> elements;
+
+	// locus -> fieldCount -> "this row's own first fieldCount fields" -> row indices.
+	// Populated for every fieldCount from 1 up to each row's own full field count, so a row's
+	// entry at fieldCount == its own length is its "full string" entry (comparisonLength ==
+	// this row's length, the row is the shorter/equal side), and entries at fieldCount < its
+	// own length exist so a *shorter* query can still find it (comparisonLength == the query's
+	// length, this row is the longer side but truncates down to match).
+	private final Map<Locus, Map<Integer, Map<String, List<Integer>>>> ownLengthIndex =
+			new HashMap<Locus, Map<Integer, Map<String, List<Integer>>>>();
+
+	private final Map<Locus, Map<String, List<Integer>>> arsIndex =
+			new HashMap<Locus, Map<String, List<Integer>>>();
+
+	// Rows whose DRB345 allele list contains the "no DRB345 gene" placeholder (DASH or NNNN) --
+	// the only rows the DRB345-homozygous special case in equals() can ever bypass a match for.
+	// Reference DisequilibriumElements never carry a Haplotype of their own (HLAFrequenciesLoader
+	// never calls setHaplotype() when building them -- confirmed by reading it), so the special
+	// case's *other* clause (checking element1's own haplotype) never applies to reference rows;
+	// only the query's own getDrb345Homozygous() flag matters here.
+	private final Set<Integer> drb345PlaceholderRows = new LinkedHashSet<Integer>();
+
+	private DisequilibriumElementIndex(List<DisequilibriumElement> elements) {
+		this.elements = elements;
+		build();
+	}
+
+	static synchronized DisequilibriumElementIndex forElements(List<DisequilibriumElement> elements) {
+		DisequilibriumElementIndex index = CACHE.get(elements);
+
+		if (index == null) {
+			index = new DisequilibriumElementIndex(elements);
+			CACHE.put(elements, index);
+		}
+
+		return index;
+	}
+
+	private void build() {
+		HashMap<String, HashSet<String>> arsMap;
+
+		try {
+			arsMap = AntigenRecognitionSiteLoader.getInstance().getArsMap();
+		}
+		catch (IOException | InvalidFormatException e) {
+			LOGGER.warning("Could not load ars data while building DisequilibriumElementIndex.");
+			arsMap = new HashMap<String, HashSet<String>>();
+		}
+
+		for (int rowIndex = 0; rowIndex < elements.size(); rowIndex++) {
+			DisequilibriumElement row = elements.get(rowIndex);
+
+			for (Locus locus : row.getLoci()) {
+				List<String> alleles = row.getHlaElement(locus);
+
+				if (alleles == null) {
+					continue;
+				}
+
+				for (String allele : alleles) {
+					indexFieldPrefixes(locus, allele, rowIndex);
+					indexArsCodes(arsMap, locus, allele, rowIndex);
+
+					if (Locus.isDRB345(locus) && (GLStringConstants.DASH.equals(allele) || GLStringConstants.NNNN.equals(allele))) {
+						drb345PlaceholderRows.add(rowIndex);
+					}
+				}
+			}
+		}
+	}
+
+	private void indexFieldPrefixes(Locus locus, String allele, int rowIndex) {
+		String[] fields = allele.split(GLStringUtilities.COLON);
+		Map<Integer, Map<String, List<Integer>>> byLength = ownLengthIndex.get(locus);
+
+		if (byLength == null) {
+			byLength = new HashMap<Integer, Map<String, List<Integer>>>();
+			ownLengthIndex.put(locus, byLength);
+		}
+
+		StringBuilder prefix = new StringBuilder();
+		for (int fieldCount = 1; fieldCount <= fields.length; fieldCount++) {
+			if (fieldCount > 1) {
+				prefix.append(GLStringUtilities.COLON);
+			}
+			prefix.append(fields[fieldCount - 1]);
+
+			Map<String, List<Integer>> byPrefix = byLength.get(fieldCount);
+			if (byPrefix == null) {
+				byPrefix = new HashMap<String, List<Integer>>();
+				byLength.put(fieldCount, byPrefix);
+			}
+
+			addIndexEntry(byPrefix, prefix.toString(), rowIndex);
+		}
+	}
+
+	private void indexArsCodes(HashMap<String, HashSet<String>> arsMap, Locus locus, String allele, int rowIndex) {
+		HashSet<String> codes = arsMap.get(allele);
+
+		if (codes == null) {
+			return;
+		}
+
+		Map<String, List<Integer>> byCode = arsIndex.get(locus);
+		if (byCode == null) {
+			byCode = new HashMap<String, List<Integer>>();
+			arsIndex.put(locus, byCode);
+		}
+
+		for (String code : codes) {
+			addIndexEntry(byCode, code, rowIndex);
+		}
+	}
+
+	private static void addIndexEntry(Map<String, List<Integer>> index, String key, int rowIndex) {
+		List<Integer> rowIndices = index.get(key);
+		if (rowIndices == null) {
+			rowIndices = new ArrayList<Integer>();
+			index.put(key, rowIndices);
+		}
+		// Reference data is loaded with one entry per unique G-group string (see
+		// HLAFrequenciesLoader#loadStandardReferenceData), so in practice this list rarely grows
+		// past one -- but nothing here assumes that.
+		if (rowIndices.isEmpty() || !rowIndices.get(rowIndices.size() - 1).equals(rowIndex)) {
+			rowIndices.add(rowIndex);
+		}
+	}
+
+	/**
+	 * All elements of the original list that {@code query.equals(element)} would return true
+	 * for, in the original list's order -- exactly what a forward scan with
+	 * {@code List#indexOf}/{@code List#subList} would have found, just without doing one.
+	 * Every candidate the index surfaces is confirmed with the real {@code equals()} before
+	 * being included.
+	 */
+	List<DisequilibriumElement> findMatches(DisequilibriumElement query) {
+		Set<Integer> candidateIndices = null;
+
+		for (Locus locus : query.getLoci()) {
+			Set<Integer> locusMatches = matchesAtLocus(query, locus);
+
+			if (candidateIndices == null) {
+				candidateIndices = locusMatches;
+			}
+			else {
+				candidateIndices.retainAll(locusMatches);
+			}
+
+			if (candidateIndices.isEmpty()) {
+				return Collections.emptyList();
+			}
+		}
+
+		if (candidateIndices == null) {
+			return Collections.emptyList();
+		}
+
+		List<Integer> sortedIndices = new ArrayList<Integer>(candidateIndices);
+		Collections.sort(sortedIndices);
+
+		List<DisequilibriumElement> verified = new ArrayList<DisequilibriumElement>();
+		for (Integer rowIndex : sortedIndices) {
+			DisequilibriumElement candidate = elements.get(rowIndex);
+			// Defense in depth: the index is only ever used to narrow down which rows are worth
+			// checking. The real equals() -- the actual, unmodified source of truth -- still
+			// decides whether each one really matches.
+			if (query.equals(candidate)) {
+				verified.add(candidate);
+			}
+		}
+
+		return verified;
+	}
+
+	private Set<Integer> matchesAtLocus(DisequilibriumElement query, Locus locus) {
+		Set<Integer> locusMatches = new LinkedHashSet<Integer>();
+		List<String> queryAlleles = query.getHlaElement(locus);
+
+		if (queryAlleles != null) {
+			Map<Integer, Map<String, List<Integer>>> byLength = ownLengthIndex.get(locus);
+			Map<String, List<Integer>> byArsCode = arsIndex.get(locus);
+
+			for (String queryAllele : queryAlleles) {
+				String[] fields = queryAllele.split(GLStringUtilities.COLON);
+
+				if (byLength != null) {
+					StringBuilder prefix = new StringBuilder();
+					for (int fieldCount = 1; fieldCount <= fields.length; fieldCount++) {
+						if (fieldCount > 1) {
+							prefix.append(GLStringUtilities.COLON);
+						}
+						prefix.append(fields[fieldCount - 1]);
+
+						Map<String, List<Integer>> byPrefix = byLength.get(fieldCount);
+						if (byPrefix != null) {
+							List<Integer> hits = byPrefix.get(prefix.toString());
+							if (hits != null) {
+								locusMatches.addAll(hits);
+							}
+						}
+					}
+				}
+
+				if (byArsCode != null) {
+					String matchedValue = GLStringUtilities.convertToProteinLevel(queryAllele);
+					if (matchedValue != null) {
+						List<Integer> hits = byArsCode.get(matchedValue);
+						if (hits != null) {
+							locusMatches.addAll(hits);
+						}
+					}
+				}
+			}
+		}
+
+		if (Locus.isDRB345(locus) && query.getHaplotype() != null && query.getHaplotype().getDrb345Homozygous()) {
+			locusMatches.addAll(drb345PlaceholderRows);
+		}
+
+		return locusMatches;
+	}
+}

--- a/ld-validation/src/main/java/org/dash/valid/DisequilibriumElementIndex.java
+++ b/ld-validation/src/main/java/org/dash/valid/DisequilibriumElementIndex.java
@@ -49,9 +49,15 @@ import org.dash.valid.gl.GLStringUtilities;
  * (ARS/G-group membership) -- so a plain {@code Map<String, DisequilibriumElement>} keyed by
  * allele string would silently miss real matches. This class instead builds, per locus:
  * <ul>
- * <li>a field-prefix index covering every reference row at every truncation depth its own
- *     allele string supports, so a query allele of any length finds every row whose comparison
- *     (at whichever length is shorter) would agree; and</li>
+ * <li>a field-prefix index, split into two maps so a query never has to consult a bucket sized
+ *     by "every row that happens to share a short prefix" -- {@code sameLengthIndex} holds each
+ *     row once, keyed by its own exact field count and full string; {@code longerRowPrefixIndex}
+ *     holds a row's prefix at length K only for K strictly less than the row's own length (i.e.
+ *     only where it's actually needed, to satisfy a query shorter than the row itself). A query
+ *     of length Lq checks {@code sameLengthIndex} at every K from 1 to Lq (catching every row
+ *     whose own length is <= Lq) plus {@code longerRowPrefixIndex} at exactly K=Lq (catching
+ *     rows longer than the query) -- never a generic "everyone sharing my first field" bucket;
+ *     and</li>
  * <li>an ARS-code index, inverting {@link AntigenRecognitionSiteLoader}'s existing map against
  *     the reference rows actually present.</li>
  * </ul>
@@ -77,13 +83,19 @@ class DisequilibriumElementIndex {
 
 	private final List<DisequilibriumElement> elements;
 
-	// locus -> fieldCount -> "this row's own first fieldCount fields" -> row indices.
-	// Populated for every fieldCount from 1 up to each row's own full field count, so a row's
-	// entry at fieldCount == its own length is its "full string" entry (comparisonLength ==
-	// this row's length, the row is the shorter/equal side), and entries at fieldCount < its
-	// own length exist so a *shorter* query can still find it (comparisonLength == the query's
-	// length, this row is the longer side but truncates down to match).
-	private final Map<Locus, Map<Integer, Map<String, List<Integer>>>> ownLengthIndex =
+	// locus -> exact field count -> row's own full string at that field count -> row indices.
+	// Each row appears exactly once here, at its own natural length -- unlike a single map
+	// covering every truncation depth, this never lets a short, widely-shared prefix (e.g. every
+	// 4-field allele's first field) sweep in rows that don't actually belong at that length.
+	private final Map<Locus, Map<Integer, Map<String, List<Integer>>>> sameLengthIndex =
+			new HashMap<Locus, Map<Integer, Map<String, List<Integer>>>>();
+
+	// locus -> K -> a row's own first-K-fields -> row indices, but ONLY for rows whose own length
+	// is strictly greater than K. Exists so a query *shorter* than some reference row can still
+	// find it (comparisonLength == the query's own length, the row truncates down to match) --
+	// looked up at exactly K == the query's own length, not swept in in bulk the way
+	// sameLengthIndex's per-length buckets are.
+	private final Map<Locus, Map<Integer, Map<String, List<Integer>>>> longerRowPrefixIndex =
 			new HashMap<Locus, Map<Integer, Map<String, List<Integer>>>>();
 
 	private final Map<Locus, Map<String, List<Integer>>> arsIndex =
@@ -148,28 +160,44 @@ class DisequilibriumElementIndex {
 
 	private void indexFieldPrefixes(Locus locus, String allele, int rowIndex) {
 		String[] fields = allele.split(GLStringUtilities.COLON);
-		Map<Integer, Map<String, List<Integer>>> byLength = ownLengthIndex.get(locus);
-
-		if (byLength == null) {
-			byLength = new HashMap<Integer, Map<String, List<Integer>>>();
-			ownLengthIndex.put(locus, byLength);
-		}
+		int ownLength = fields.length;
 
 		StringBuilder prefix = new StringBuilder();
-		for (int fieldCount = 1; fieldCount <= fields.length; fieldCount++) {
+		for (int fieldCount = 1; fieldCount <= ownLength; fieldCount++) {
 			if (fieldCount > 1) {
 				prefix.append(GLStringUtilities.COLON);
 			}
 			prefix.append(fields[fieldCount - 1]);
 
-			Map<String, List<Integer>> byPrefix = byLength.get(fieldCount);
-			if (byPrefix == null) {
-				byPrefix = new HashMap<String, List<Integer>>();
-				byLength.put(fieldCount, byPrefix);
+			if (fieldCount == ownLength) {
+				addIndexEntry(bucketFor(sameLengthIndex, locus, fieldCount), prefix.toString(), rowIndex);
 			}
-
-			addIndexEntry(byPrefix, prefix.toString(), rowIndex);
+			else {
+				addIndexEntry(bucketFor(longerRowPrefixIndex, locus, fieldCount), prefix.toString(), rowIndex);
+			}
 		}
+	}
+
+	private static Map<String, List<Integer>> bucketFor(Map<Locus, Map<Integer, Map<String, List<Integer>>>> index, Locus locus, int fieldCount) {
+		Map<Integer, Map<String, List<Integer>>> byLength = index.get(locus);
+		if (byLength == null) {
+			byLength = new HashMap<Integer, Map<String, List<Integer>>>();
+			index.put(locus, byLength);
+		}
+
+		Map<String, List<Integer>> byPrefix = byLength.get(fieldCount);
+		if (byPrefix == null) {
+			byPrefix = new HashMap<String, List<Integer>>();
+			byLength.put(fieldCount, byPrefix);
+		}
+
+		return byPrefix;
+	}
+
+	// Read-only counterpart to bucketFor() -- never creates a bucket, just looks one up.
+	private static List<Integer> bucketAt(Map<Integer, Map<String, List<Integer>>> byLength, int fieldCount, String key) {
+		Map<String, List<Integer>> byPrefix = byLength.get(fieldCount);
+		return byPrefix == null ? null : byPrefix.get(key);
 	}
 
 	private void indexArsCodes(HashMap<String, HashSet<String>> arsMap, Locus locus, String allele, int rowIndex) {
@@ -255,27 +283,46 @@ class DisequilibriumElementIndex {
 		List<String> queryAlleles = query.getHlaElement(locus);
 
 		if (queryAlleles != null) {
-			Map<Integer, Map<String, List<Integer>>> byLength = ownLengthIndex.get(locus);
+			Map<Integer, Map<String, List<Integer>>> sameLengthByLength = sameLengthIndex.get(locus);
+			Map<Integer, Map<String, List<Integer>>> longerByLength = longerRowPrefixIndex.get(locus);
 			Map<String, List<Integer>> byArsCode = arsIndex.get(locus);
 
 			for (String queryAllele : queryAlleles) {
 				String[] fields = queryAllele.split(GLStringUtilities.COLON);
+				int queryLength = fields.length;
 
-				if (byLength != null) {
+				if (sameLengthByLength != null) {
 					StringBuilder prefix = new StringBuilder();
-					for (int fieldCount = 1; fieldCount <= fields.length; fieldCount++) {
+					for (int fieldCount = 1; fieldCount <= queryLength; fieldCount++) {
 						if (fieldCount > 1) {
 							prefix.append(GLStringUtilities.COLON);
 						}
 						prefix.append(fields[fieldCount - 1]);
 
-						Map<String, List<Integer>> byPrefix = byLength.get(fieldCount);
+						// Rows whose own natural length is exactly fieldCount -- comparisonLength
+						// == fieldCount == that row's length, so its full string must equal this
+						// prefix. Checked at every fieldCount up to the query's own length, since
+						// any of those shorter-or-equal natural lengths could be the shorter side.
+						Map<String, List<Integer>> byPrefix = sameLengthByLength.get(fieldCount);
 						if (byPrefix != null) {
 							List<Integer> hits = byPrefix.get(prefix.toString());
 							if (hits != null) {
 								locusMatches.addAll(hits);
 							}
 						}
+					}
+				}
+
+				if (longerByLength != null) {
+					// Rows longer than the query -- comparisonLength == the query's own length,
+					// so only rows whose prefix at exactly that length equals the query's full
+					// (untruncated) string are candidates. A single lookup, not swept in via the
+					// loop above, since a shorter-than-query fieldCount here would only match
+					// rows that are also longer than *that* fieldCount but no claim is made about
+					// their remaining fields matching the query at all.
+					List<Integer> hits = bucketAt(longerByLength, queryLength, queryAllele);
+					if (hits != null) {
+						locusMatches.addAll(hits);
 					}
 				}
 

--- a/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
+++ b/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
@@ -179,10 +179,9 @@ public class HLALinkageDisequilibrium {
 	 * @return a copy of {@code haplotype}, annotated with a linkage if one was found
 	 */
 	public static Haplotype enrichHaplotype(EnumSet<Locus> loci, List<DisequilibriumElement> disequilibriumElements, Haplotype haplotype) {
-		MultiLocusHaplotype enrichedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(haplotype.getAlleleMap()), 
+		MultiLocusHaplotype enrichedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(haplotype.getAlleleMap()),
 				new HashMap<Locus, Integer>(haplotype.getHaplotypeInstanceMap()), haplotype.getDrb345Homozygous());
 		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
-		List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
 
 		for (Locus locus : enrichedHaplotype.getLoci()) {
 			if (loci.contains(locus)) {
@@ -192,21 +191,25 @@ public class HLALinkageDisequilibrium {
 				enrichedHaplotype.removeAlleles(locus);
 			}
 		}
-		
+
 		DisequilibriumElement element = new CoreDisequilibriumElement(hlaElementMap, enrichedHaplotype);
-		DetectedDisequilibriumElement detectedElement = null;
-					
-		while (shortenedList.contains(element)) {
-			int index = shortenedList.indexOf(element);
-			detectedElement = new DetectedDisequilibriumElement(shortenedList.get(index));
+
+		// Was a manual List#contains()/indexOf()/subList() linear scan over the full (possibly
+		// 900K+ row, for a real custom-uploaded frequency file) reference list, repeated once per
+		// match found. DisequilibriumElementIndex finds the identical set of matches (equals()
+		// itself is unchanged and still has the final say -- see its javadoc) without scanning
+		// the whole list per lookup. Keeps the original's "last match found wins" behavior: the
+		// loop below overwrites the linkage on every iteration, same as the old while-loop did.
+		List<DisequilibriumElement> matches = DisequilibriumElementIndex.forElements(disequilibriumElements).findMatches(element);
+
+		for (DisequilibriumElement match : matches) {
+			DetectedDisequilibriumElement detectedElement = new DetectedDisequilibriumElement(match);
 			detectedElement.setHaplotype(element.getHaplotype());
 			enrichedHaplotype.setLinkage(detectedElement);
-			
-			shortenedList = shortenedList.subList(index + 1, shortenedList.size());
 		}
-		
+
 		enrichedHaplotype.setSequence(haplotype.getSequence());
-		
+
 		return enrichedHaplotype;
 	}
 	
@@ -237,9 +240,12 @@ public class HLALinkageDisequilibrium {
 
 		MultiLocusHaplotype clonedHaplotype = null;
 
-		for (MultiLocusHaplotype possibleHaplotype : glString.getPossibleHaplotypes(loci)) {
-			List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
+		// disequilibriumElements can be huge (900K+ rows for a real custom-uploaded frequency
+		// file); the index below is built once (and cached by list identity) rather than once
+		// per possibleHaplotype the way the old List#contains()/indexOf() scan effectively was.
+		DisequilibriumElementIndex index = DisequilibriumElementIndex.forElements(disequilibriumElements);
 
+		for (MultiLocusHaplotype possibleHaplotype : glString.getPossibleHaplotypes(loci)) {
 			HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
 
 			for (Locus locus : possibleHaplotype.getLoci()) {
@@ -250,12 +256,15 @@ public class HLALinkageDisequilibrium {
 			}
 
 			DisequilibriumElement element = new CoreDisequilibriumElement(hlaElementMap, possibleHaplotype);
-			DetectedDisequilibriumElement detectedElement = null;
 
-			while (shortenedList.contains(element)) {
-				int index = shortenedList.indexOf(element);
+			// Was a manual List#contains()/indexOf()/subList() linear scan finding matches one at
+			// a time. index.findMatches() returns the identical set (equals() itself is
+			// unchanged -- see DisequilibriumElementIndex's javadoc for why a naive string-keyed
+			// Map isn't safe here) in the same list order, so this loop's tie-break behavior below
+			// is unchanged from the original while-loop's.
+			for (DisequilibriumElement match : index.findMatches(element)) {
 				clonedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(possibleHaplotype.getAlleleMap()), possibleHaplotype.getHaplotypeInstanceMap(), possibleHaplotype.getDrb345Homozygous());
-				detectedElement = new DetectedDisequilibriumElement(shortenedList.get(index));
+				DetectedDisequilibriumElement detectedElement = new DetectedDisequilibriumElement(match);
 				detectedElement.setHaplotype(element.getHaplotype());
 				clonedHaplotype.setLinkage(detectedElement);
 
@@ -270,8 +279,6 @@ public class HLALinkageDisequilibrium {
 							+ clonedHaplotype.getFullHaplotypeString() + " over " + existingHaplotype.getFullHaplotypeString());
 					linkedHaplotypesByValue.put(haplotypeValue, clonedHaplotype);
 				}
-
-				shortenedList = shortenedList.subList(index + 1, shortenedList.size());
 			}
 		}
 

--- a/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
+++ b/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
@@ -182,7 +182,15 @@ public class HLALinkageDisequilibrium {
 		MultiLocusHaplotype enrichedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(haplotype.getAlleleMap()), 
 				new HashMap<Locus, Integer>(haplotype.getHaplotypeInstanceMap()), haplotype.getDrb345Homozygous());
 		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
-		List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
+		// Was: new ArrayList<>(disequilibriumElements) -- a full copy of the (potentially huge,
+		// e.g. 900K+ rows for a real custom-uploaded frequency file) reference list, made fresh
+		// for every single haplotype checked. disequilibriumElements is HLAFrequenciesLoader's
+		// own live, shared list (see #getDisequilibriumElements) -- callers here only ever read
+		// from shortenedList (.contains()/.indexOf()/.get()/.subList()), never mutate it, so
+		// there's nothing the copy was protecting against. A subList() view (or, as here, the
+		// list itself, since subList() start=0 is just the list) behaves identically for every
+		// operation this method performs, without allocating and copying the whole thing.
+		List<DisequilibriumElement> shortenedList = disequilibriumElements;
 
 		for (Locus locus : enrichedHaplotype.getLoci()) {
 			if (loci.contains(locus)) {
@@ -238,7 +246,11 @@ public class HLALinkageDisequilibrium {
 		MultiLocusHaplotype clonedHaplotype = null;
 
 		for (MultiLocusHaplotype possibleHaplotype : glString.getPossibleHaplotypes(loci)) {
-			List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
+			// See the identical comment in enrichHaplotype() above: this used to copy the full
+			// (potentially huge) reference list per candidate haplotype for no reason -- nothing
+			// here mutates shortenedList, so referencing disequilibriumElements directly is
+			// behaviorally identical and avoids that copy.
+			List<DisequilibriumElement> shortenedList = disequilibriumElements;
 
 			HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
 

--- a/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
+++ b/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
@@ -1,0 +1,189 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.ars;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.dash.valid.gl.GLStringConstants;
+
+/**
+ * Local, on-disk cache for {@link AntigenRecognitionSiteLoader}'s parsed ARS/G-group map, keyed
+ * by hladb version. Fetching and parsing {@code hla_ambigs.xml.zip} costs real time (a real,
+ * decompressed 1.5GB+ XML file at the time of writing, streamed and tokenized every time it's
+ * needed) -- for a <em>pinned</em> hladb version (e.g. {@code "3.65.0"}) that data can never
+ * change once IMGT/HLA publishes it, so there's no reason to re-fetch and re-parse it on every
+ * process run.
+ * <p>
+ * {@link GLStringConstants#LATEST_HLADB} ({@code "Latest"}) is the one exception: it's a moving
+ * GitHub branch, not a pinned release, so caching it forever would silently serve stale data
+ * after IMGT/HLA's next release. Entries for it expire after {@link #LATEST_TTL_MILLIS} instead
+ * of being kept indefinitely.
+ * <p>
+ * Every method here is purely best-effort: a missing, corrupt, unreadable, or expired cache
+ * entry is treated as a plain cache miss (never thrown), and a failure to write is logged and
+ * swallowed -- the caller already has a correct, freshly-parsed result regardless of whether the
+ * cache write succeeds. Nothing about correctness depends on this class working.
+ */
+class AntigenRecognitionSiteCache {
+	private static final Logger LOGGER = Logger.getLogger(AntigenRecognitionSiteCache.class.getName());
+
+	/**
+	 * Overrides the cache directory (default: {@code ~/.dash-cache/ars}). Not something a user
+	 * needs to set for normal use -- this exists for edge cases like a read-only home directory
+	 * or a container, the same spirit as {@link GLStringConstants#HLADB_PROPERTY} and friends.
+	 */
+	public static final String ARS_CACHE_DIR_PROPERTY = "org.dash.arsCacheDir";
+
+	private static final String CACHED_AT_PREFIX = "#cachedAt=";
+	private static final long LATEST_TTL_MILLIS = TimeUnit.HOURS.toMillis(24);
+
+	private AntigenRecognitionSiteCache() {
+	}
+
+	/**
+	 * @param hladb the hladb this data would be for (never null -- callers already default it)
+	 * @return the cached ARS map, or {@code null} on any cache miss (not present, unreadable,
+	 *         wrong format, or -- for {@link GLStringConstants#LATEST_HLADB} only -- expired)
+	 */
+	static HashMap<String, HashSet<String>> read(String hladb) {
+		File file = cacheFile(hladb);
+
+		if (!file.isFile()) {
+			return null;
+		}
+
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+			String header = reader.readLine();
+			if (header == null || !header.startsWith(CACHED_AT_PREFIX)) {
+				return null;
+			}
+
+			long cachedAt = Long.parseLong(header.substring(CACHED_AT_PREFIX.length()));
+			if (GLStringConstants.LATEST_HLADB.equals(hladb) && System.currentTimeMillis() - cachedAt > LATEST_TTL_MILLIS) {
+				return null;
+			}
+
+			HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				int tab = line.indexOf('\t');
+				if (tab < 0) {
+					continue;
+				}
+
+				String arsCode = line.substring(0, tab);
+				String allelesJoined = line.substring(tab + 1);
+				HashSet<String> alleles = new HashSet<String>();
+				// An empty gGroup (no gGroupAllele children) is stored as an empty string here --
+				// "".split(",") returns [""], not [], so this must be checked explicitly or a
+				// bogus single empty-string allele would be reconstructed.
+				if (!allelesJoined.isEmpty()) {
+					alleles.addAll(Arrays.asList(allelesJoined.split(",")));
+				}
+				arsMap.put(arsCode, alleles);
+			}
+
+			return arsMap;
+		}
+		catch (Exception e) {
+			LOGGER.info("Ignoring unreadable ARS cache file " + file + ": " + e);
+			return null;
+		}
+	}
+
+	/**
+	 * Best-effort write; any failure is logged and swallowed rather than propagated, since a
+	 * cache write failing doesn't affect the correctness of the result the caller already has.
+	 *
+	 * @param hladb the hladb this data is for
+	 * @param arsMap the freshly-parsed map to persist
+	 */
+	static void write(String hladb, HashMap<String, HashSet<String>> arsMap) {
+		File dir = cacheDir();
+
+		try {
+			Files.createDirectories(dir.toPath());
+
+			// Created directly inside the target directory (not the system temp dir) so the
+			// final Files.move() below is guaranteed to be on the same filesystem -- required
+			// for ATOMIC_MOVE to actually be atomic rather than silently falling back to a
+			// non-atomic copy-then-delete.
+			File tempFile = File.createTempFile("ars-", ".tmp", dir);
+
+			try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8))) {
+				writer.write(CACHED_AT_PREFIX + System.currentTimeMillis());
+				writer.newLine();
+
+				for (Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+					writer.write(entry.getKey());
+					writer.write('\t');
+					writer.write(String.join(",", entry.getValue()));
+					writer.newLine();
+				}
+			}
+
+			Files.move(tempFile.toPath(), cacheFile(hladb).toPath(),
+					StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		}
+		catch (Exception e) {
+			LOGGER.info("Couldn't write ARS cache for hladb " + hladb + ": " + e);
+		}
+	}
+
+	// Package-private (not private) so tests can locate the exact file this class would read
+	// from/write to, to exercise edge cases (corruption, expiry) that require crafting a cache
+	// file's content directly rather than going through write().
+	static File cacheFile(String hladb) {
+		// Matches the same normalization AntigenRecognitionSiteLoader#loadGGroups uses to build
+		// the fetch URL, so the cache key exactly tracks whatever actually determines the
+		// content (e.g. "3.65.0" and "3.65.0" -- the only form this ever legitimately takes --
+		// both normalize to "3650"). Sanitized defensively in case some future hladb value ever
+		// contains characters that aren't safe in a filename.
+		String normalized = hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING);
+		String safeName = normalized.replaceAll("[^A-Za-z0-9_-]", "_");
+		return new File(cacheDir(), "ars-" + safeName + ".cache");
+	}
+
+	private static File cacheDir() {
+		String override = System.getProperty(ARS_CACHE_DIR_PROPERTY);
+		if (override != null && !override.isEmpty()) {
+			return new File(override);
+		}
+
+		return new File(System.getProperty("user.home"), ".dash-cache" + File.separator + "ars");
+	}
+}

--- a/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
+++ b/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
@@ -134,6 +134,7 @@ class AntigenRecognitionSiteCache {
 	 */
 	static void write(String hladb, HashMap<String, HashSet<String>> arsMap) {
 		File dir = cacheDir();
+		File tempFile = null;
 
 		try {
 			Files.createDirectories(dir.toPath());
@@ -142,13 +143,22 @@ class AntigenRecognitionSiteCache {
 			// final Files.move() below is guaranteed to be on the same filesystem -- required
 			// for ATOMIC_MOVE to actually be atomic rather than silently falling back to a
 			// non-atomic copy-then-delete.
-			File tempFile = File.createTempFile("ars-", ".tmp", dir);
+			tempFile = File.createTempFile("ars-", ".tmp", dir);
 
 			try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8))) {
 				writer.write(CACHED_AT_PREFIX + System.currentTimeMillis());
 				writer.newLine();
 
 				for (Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+					// A null key here would throw (BufferedWriter#write(null) is an NPE) and be
+					// swallowed by the catch below -- confirmed as a real failure mode for the
+					// analogous CommonWellDocumentedCache (a null map key does occur in real
+					// data there). arsCode is always non-null by construction in this loader, but
+					// skipping defensively costs nothing and keeps the rest of a real map
+					// cacheable even if that ever stops being true.
+					if (entry.getKey() == null) {
+						continue;
+					}
 					writer.write(entry.getKey());
 					writer.write('\t');
 					writer.write(String.join(",", entry.getValue()));
@@ -161,6 +171,12 @@ class AntigenRecognitionSiteCache {
 		}
 		catch (Exception e) {
 			LOGGER.info("Couldn't write ARS cache for hladb " + hladb + ": " + e);
+			// Best-effort cleanup so a write failure (whatever the cause) doesn't leave orphaned
+			// .tmp files behind indefinitely -- this is the one path Files.move() above never
+			// reaches, so tempFile would otherwise just sit in the cache directory forever.
+			if (tempFile != null) {
+				tempFile.delete();
+			}
 		}
 	}
 

--- a/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteLoader.java
+++ b/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteLoader.java
@@ -22,7 +22,9 @@
 package org.dash.valid.ars;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -115,15 +117,40 @@ public class AntigenRecognitionSiteLoader {
 	// gGroup/gGroupAllele elements don't nest inside each other (only inside gene, whose
 	// own attributes are never used), so tracking "are we inside a gGroup" as a single flag
 	// while streaming is enough to reproduce the original nesting-scoped behavior.
+	//
+	// Two further, separately-verified findings from actually profiling this against the real
+	// file: decompressed, hla_ambigs.xml.zip is 1.5GB+ (16M+ lines), of which 99.88% is
+	// <tns:ambigCombosList> content this method never reads at all -- but a dedicated StAX
+	// implementation's own skipElement() (tested directly, via Woodstox) turned out not to help,
+	// since the underlying tokenizer still has to character-scan past skipped content either
+	// way. What does help:
+	// 1. AntigenRecognitionSiteCache -- for a *pinned* hladb (anything but LATEST_HLADB, which
+	//    is a moving branch, not a release), this data can never change once published, so
+	//    there's no reason to ever fetch or parse it more than once on a given machine.
+	// 2. Buffering the whole (compressed) response before parsing, instead of tokenizing
+	//    directly off the live network socket -- measured ~24s streamed live vs. ~13s from an
+	//    otherwise-identical already-downloaded local file for this exact file, i.e. roughly
+	//    half the wall-clock cost was network-interleaving overhead, not parsing itself.
 	public static HashMap<String, HashSet<String>> loadGGroups(String hladb) throws MalformedURLException, IOException, ParserConfigurationException, SAXException {
 		if (hladb == null) hladb = GLStringConstants.LATEST_HLADB;
+
+		HashMap<String, HashSet<String>> cached = AntigenRecognitionSiteCache.read(hladb);
+		if (cached != null) {
+			return cached;
+		}
+
 		URL url = new URL("https://raw.githubusercontent.com/ANHIG/IMGTHLA/" + hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING) + "/xml/hla_ambigs.xml.zip");
 
 		System.out.println(url.toString());
 
 		HashMap<String, HashSet<String>> gAlleleListMap = new HashMap<String, HashSet<String>>();
 
-		try (ZipInputStream zipStream = new ZipInputStream(url.openStream())) {
+		byte[] responseBytes;
+		try (InputStream urlStream = url.openStream()) {
+			responseBytes = urlStream.readAllBytes();
+		}
+
+		try (ZipInputStream zipStream = new ZipInputStream(new ByteArrayInputStream(responseBytes))) {
 			zipStream.getNextEntry();
 
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
@@ -189,6 +216,8 @@ public class AntigenRecognitionSiteLoader {
 		catch (XMLStreamException e) {
 			throw new IOException("Problem streaming IMGT/HLA ambiguity XML for hladb: " + hladb, e);
 		}
+
+		AntigenRecognitionSiteCache.write(hladb, gAlleleListMap);
 
 		return gAlleleListMap;
 	}

--- a/ld-validation/src/main/java/org/dash/valid/cwd/CommonWellDocumentedCache.java
+++ b/ld-validation/src/main/java/org/dash/valid/cwd/CommonWellDocumentedCache.java
@@ -1,0 +1,201 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.cwd;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.dash.valid.gl.GLStringConstants;
+
+/**
+ * Local, on-disk cache for {@link CommonWellDocumentedLoader#loadFromIMGT}'s parsed accession
+ * map, keyed by hladb version. Same rationale, same design as
+ * {@link org.dash.valid.ars.AntigenRecognitionSiteCache} (see its javadoc for the full
+ * background) -- {@code hla.xml.zip} is a real, multi-MB-per-release file that's expensive to
+ * fetch and parse, and for a <em>pinned</em> hladb version that data can never change once
+ * IMGT/HLA publishes it.
+ * <p>
+ * {@link GLStringConstants#LATEST_HLADB} entries expire after {@link #LATEST_TTL_MILLIS} instead
+ * of being kept indefinitely, since {@code "Latest"} is a moving GitHub branch, not a pinned
+ * release.
+ * <p>
+ * Purely best-effort throughout: a missing, corrupt, unreadable, or expired entry is a plain
+ * cache miss (never thrown), and a write failure is logged and swallowed. Nothing about
+ * correctness depends on this class working.
+ */
+class CommonWellDocumentedCache {
+	private static final Logger LOGGER = Logger.getLogger(CommonWellDocumentedCache.class.getName());
+
+	/**
+	 * Overrides the cache directory (default: {@code ~/.dash-cache/cwd}). Same spirit as
+	 * {@link org.dash.valid.ars.AntigenRecognitionSiteCache#ARS_CACHE_DIR_PROPERTY} -- an edge-case
+	 * escape hatch, not something normal use requires setting.
+	 */
+	public static final String CWD_CACHE_DIR_PROPERTY = "org.dash.cwdCacheDir";
+
+	private static final String CACHED_AT_PREFIX = "#cachedAt=";
+	private static final long LATEST_TTL_MILLIS = TimeUnit.HOURS.toMillis(24);
+
+	private CommonWellDocumentedCache() {
+	}
+
+	/**
+	 * @param hladb the hladb this data would be for (never null -- callers already default it)
+	 * @return the cached accession map, or {@code null} on any cache miss
+	 */
+	static HashMap<String, List<String>> read(String hladb) {
+		File file = cacheFile(hladb);
+
+		if (!file.isFile()) {
+			return null;
+		}
+
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+			String header = reader.readLine();
+			if (header == null || !header.startsWith(CACHED_AT_PREFIX)) {
+				return null;
+			}
+
+			long cachedAt = Long.parseLong(header.substring(CACHED_AT_PREFIX.length()));
+			if (GLStringConstants.LATEST_HLADB.equals(hladb) && System.currentTimeMillis() - cachedAt > LATEST_TTL_MILLIS) {
+				return null;
+			}
+
+			HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				int tab = line.indexOf('\t');
+				if (tab < 0) {
+					continue;
+				}
+
+				String name = line.substring(0, tab);
+				String accessionsJoined = line.substring(tab + 1);
+				List<String> accessions = new ArrayList<String>();
+				// An entry with no accessions at all is stored as an empty string --
+				// "".split(",") returns [""], not [], so this must be checked explicitly, same
+				// edge case as AntigenRecognitionSiteCache's empty allele sets.
+				if (!accessionsJoined.isEmpty()) {
+					accessions.addAll(Arrays.asList(accessionsJoined.split(",")));
+				}
+				accessionMap.put(name, accessions);
+			}
+
+			return accessionMap;
+		}
+		catch (Exception e) {
+			LOGGER.info("Ignoring unreadable CWD accession cache file " + file + ": " + e);
+			return null;
+		}
+	}
+
+	/**
+	 * Best-effort write; any failure is logged and swallowed rather than propagated.
+	 *
+	 * @param hladb the hladb this data is for
+	 * @param accessionMap the freshly-parsed map to persist
+	 */
+	static void write(String hladb, HashMap<String, List<String>> accessionMap) {
+		File dir = cacheDir();
+		File tempFile = null;
+
+		try {
+			Files.createDirectories(dir.toPath());
+
+			// Created directly inside the target directory so the Files.move() below is
+			// guaranteed to be on the same filesystem -- required for ATOMIC_MOVE to actually be
+			// atomic rather than silently falling back to a non-atomic copy-then-delete.
+			tempFile = File.createTempFile("cwd-", ".tmp", dir);
+
+			try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8))) {
+				writer.write(CACHED_AT_PREFIX + System.currentTimeMillis());
+				writer.newLine();
+
+				for (Map.Entry<String, List<String>> entry : accessionMap.entrySet()) {
+					// GLStringUtilities#convertToProteinLevel (whose result loadFromIMGT uses as
+					// the map key) can return null for a malformed/short allele name -- confirmed
+					// against real hla.xml.zip data, not just a theoretical case. write(null)
+					// throws NPE. Skipping the (rare, already-anomalous) null-keyed entry is a
+					// fine trade to keep the rest of a real map cacheable -- and the tempFile
+					// cleanup in the catch below means even an entry that fails for some other,
+					// unanticipated reason won't leave permanent debris either way.
+					if (entry.getKey() == null) {
+						continue;
+					}
+					writer.write(entry.getKey());
+					writer.write('\t');
+					writer.write(String.join(",", entry.getValue()));
+					writer.newLine();
+				}
+			}
+
+			Files.move(tempFile.toPath(), cacheFile(hladb).toPath(),
+					StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		}
+		catch (Exception e) {
+			LOGGER.info("Couldn't write CWD accession cache for hladb " + hladb + ": " + e);
+			// Best-effort cleanup so a write failure (whatever the cause) doesn't leave orphaned
+			// .tmp files behind indefinitely -- this is the one path Files.move() above never
+			// reaches, so tempFile would otherwise just sit in the cache directory forever.
+			if (tempFile != null) {
+				tempFile.delete();
+			}
+		}
+	}
+
+	// Package-private (not private) so tests can locate the exact file this class would read
+	// from/write to, to exercise edge cases (corruption, expiry) that require crafting a cache
+	// file's content directly rather than going through write().
+	static File cacheFile(String hladb) {
+		// Matches the same normalization CommonWellDocumentedLoader#loadFromIMGT uses to build
+		// the fetch URL, so the cache key exactly tracks whatever actually determines the
+		// content. Sanitized defensively in case some future hladb value contains characters
+		// that aren't safe in a filename.
+		String normalized = hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING);
+		String safeName = normalized.replaceAll("[^A-Za-z0-9_-]", "_");
+		return new File(cacheDir(), "cwd-" + safeName + ".cache");
+	}
+
+	private static File cacheDir() {
+		String override = System.getProperty(CWD_CACHE_DIR_PROPERTY);
+		if (override != null && !override.isEmpty()) {
+			return new File(override);
+		}
+
+		return new File(System.getProperty("user.home"), ".dash-cache" + File.separator + "cwd");
+	}
+}

--- a/ld-validation/src/main/java/org/dash/valid/cwd/CommonWellDocumentedLoader.java
+++ b/ld-validation/src/main/java/org/dash/valid/cwd/CommonWellDocumentedLoader.java
@@ -22,8 +22,10 @@
 package org.dash.valid.cwd;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.ArrayList;
@@ -92,12 +94,27 @@ public class CommonWellDocumentedLoader {
 	// worked around by pinning tests to an old HLADB version. Measured against the current
 	// latest release (3.65.0, ~22MB compressed): the DOM version needed ~2GB of heap and
 	// ~40s; this version holds only the accumulating accessionMap in memory.
+	//
+	// Also cached on disk (CommonWellDocumentedCache) and buffered before parsing, same fixes
+	// and same reasoning as AntigenRecognitionSiteLoader#loadGGroups -- see its comment for the
+	// measurements. Newly relevant here since loadCommonWellDocumentedAlleles now calls this for
+	// LATEST_HLADB too, not just pinned versions.
 	public HashMap<String, List<String>> loadFromIMGT(String hladb) throws IOException, ParserConfigurationException, SAXException {
+		HashMap<String, List<String>> cached = CommonWellDocumentedCache.read(hladb);
+		if (cached != null) {
+			return cached;
+		}
+
 		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
 
 		URL url = new URL("https://raw.githubusercontent.com/ANHIG/IMGTHLA/" + hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING) + "/xml/hla.xml.zip");
 
-		try (ZipInputStream zipStream = new ZipInputStream(url.openStream())) {
+		byte[] responseBytes;
+		try (InputStream urlStream = url.openStream()) {
+			responseBytes = urlStream.readAllBytes();
+		}
+
+		try (ZipInputStream zipStream = new ZipInputStream(new ByteArrayInputStream(responseBytes))) {
 			zipStream.getNextEntry();
 
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
@@ -137,6 +154,8 @@ public class CommonWellDocumentedLoader {
 			throw new IOException("Problem streaming IMGT/HLA XML for hladb: " + hladb, e);
 		}
 
+		CommonWellDocumentedCache.write(hladb, accessionMap);
+
 		return accessionMap;
 	}
 	
@@ -145,8 +164,29 @@ public class CommonWellDocumentedLoader {
 		HashMap<String, List<String>> accessionMap = null;
 		boolean accessionLoaded = false;
 				
-		// TODO:  Why bailing on LATEST HLADB here?
-		if (hladb == null || GLStringConstants.LATEST_HLADB.equals(hladb)) return;
+		// Was: an early return whenever hladb is null or LATEST_HLADB (added in 2017 "Turn off
+		// cwd logic if no HLA DB is known", replacing what this line now restores -- with a
+		// still-unresolved "TODO: Why bailing on LATEST HLADB here?" added later, in 2021, by
+		// the same history; neither commit explains the original reasoning). The actual effect:
+		// since that return happened before cwdSet/accessionMap were ever populated, and both
+		// fields default to empty collections, checkCommonWellDocumented()'s own
+		// "if (cwdAlleles.size() == 0) return empty" guard then unconditionally short-circuited
+		// -- meaning CWD-anomaly detection reported zero warnings, always, for every analysis
+		// that didn't explicitly pin a hladb version via -v/-Dorg.dash.hladb. Given the default
+		// (no -v flag) is very likely the most common way this tool gets run, that was a real,
+		// silent feature gap, not a deliberate scope limitation worth keeping.
+		//
+		// Verified this restores CWD-anomaly detection correctly rather than just producing
+		// noise: confirmed directly that the same input produced 0 non-cwd warnings under the
+		// old guard and 3 with a pinned version, then diffed a full real run (337 genotypes,
+		// default hladb, stanfordExamplesFixed.txt) old vs. new -- exactly one line differed in
+		// the entire output (one new, specific, plausible <non-cwd> allele finding), every other
+		// output file byte-identical. One consequence worth knowing: this means loadFromIMGT (and
+		// its hla.xml.zip fetch) now runs for LATEST_HLADB too, not just pinned versions -- see
+		// CommonWellDocumentedCache, which already accounts for this (a 24h TTL for LATEST_HLADB
+		// specifically, since unlike a pinned release it's a moving target that can't be cached
+		// forever).
+		if (hladb == null) hladb = GLStringConstants.LATEST_HLADB;
 
 		try {
 			accessionMap = loadFromIMGT(hladb);

--- a/ld-validation/src/test/java/org/dash/valid/DisequilibriumElementIndexTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/DisequilibriumElementIndexTest.java
@@ -1,0 +1,241 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.dash.valid.ars.AntigenRecognitionSiteLoader;
+import org.dash.valid.base.BaseDisequilibriumElement;
+import org.dash.valid.gl.haplo.MultiLocusHaplotype;
+import org.junit.jupiter.api.Test;
+
+// DisequilibriumElementIndex replaces a manual List#contains()/indexOf() linear scan (see
+// HLALinkageDisequilibrium) with an index, specifically so it can be fast against a reference
+// list with 900K+ rows -- but DisequilibriumElement#equals() itself does fuzzy matching (colon-
+// field prefix truncation OR ARS/G-group membership per locus, not exact string comparison), so
+// the risk here isn't "did the copy-and-scan style change" but "does the index still find every
+// match the old brute-force scan would have, and nothing else." Every test below compares the
+// index's result against bruteForceMatches() -- a deliberately trivial, obviously-correct linear
+// filter using the same, unmodified equals() -- rather than asserting expected values by hand,
+// so what's actually being verified is "the index agrees with the ground truth," not "the index
+// agrees with what I assumed."
+public class DisequilibriumElementIndexTest {
+
+	@Test
+	public void testExactMatch() {
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, "HLA-A*01:01:01:01");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01:01:01");
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference));
+	}
+
+	@Test
+	public void testFieldTruncationMatchWhenQueryIsShorterThanReference() {
+		// Query has fewer fields than the reference row -- fieldLevelComparison truncates to the
+		// query's own (shorter) length, so this must still match.
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, "HLA-A*01:01:01:01");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01");
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference));
+	}
+
+	@Test
+	public void testFieldTruncationMatchWhenQueryIsLongerThanReference() {
+		// Reverse of the above -- reference row has fewer fields, so the comparison truncates
+		// down to *its* length instead.
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, "HLA-A*01:01");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01:05:01");
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference));
+	}
+
+	@Test
+	public void testGenuineNonMatch() {
+		// No field-level overlap at all -- must not match, proving the index doesn't over-match.
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, "HLA-A*02:01");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01");
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).isEmpty());
+	}
+
+	@Test
+	public void testMultiLocusRequiresAllLociToMatch() {
+		// Matches at HLA_B but not HLA_C -- the pair must not be reported as an overall match,
+		// same as equals()'s per-locus AND.
+		HashMap<Locus, List<String>> refMap = new HashMap<Locus, List<String>>();
+		refMap.put(Locus.HLA_B, list("HLA-B*07:02"));
+		refMap.put(Locus.HLA_C, list("HLA-C*07:02"));
+		DisequilibriumElement reference = new BaseDisequilibriumElement(refMap, "1", "note");
+
+		HashMap<Locus, List<String>> queryMap = new HashMap<Locus, List<String>>();
+		queryMap.put(Locus.HLA_B, list("HLA-B*07:02"));
+		queryMap.put(Locus.HLA_C, list("HLA-C*04:01"));
+		DisequilibriumElement query = new CoreDisequilibriumElement(queryMap, haplotype());
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).isEmpty());
+	}
+
+	@Test
+	public void testMultipleTiedMatchesAreAllFound() {
+		// Two distinct reference rows both matching the same (shorter) query -- findLinkedPairs'
+		// tie-break logic depends on finding *all* of them, not just the first encountered.
+		DisequilibriumElement reference1 = referenceRow(Locus.HLA_A, "HLA-A*01:01:01:01");
+		DisequilibriumElement reference2 = referenceRow(Locus.HLA_A, "HLA-A*01:01:01:02");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01");
+
+		List<DisequilibriumElement> elements = Arrays.asList(reference1, reference2);
+		assertIndexAgreesWithBruteForce(elements, query);
+
+		List<DisequilibriumElement> matches = DisequilibriumElementIndex.forElements(elements).findMatches(query);
+		assertTrue(matches.contains(reference1));
+		assertTrue(matches.contains(reference2));
+		assertEquals(2, matches.size());
+	}
+
+	@Test
+	public void testDrb345HomozygousPlaceholderMatch() {
+		// A DRB345-homozygous query (no DRB3/4/5 gene at all) must match a reference row whose
+		// DRB345 slot is the "-" placeholder, even though the strings share no field-level prefix
+		// and aren't ARS-related -- the special case in equals() this exercises.
+		HashMap<Locus, List<String>> refMap = new HashMap<Locus, List<String>>();
+		refMap.put(Locus.HLA_DRB345, list(org.dash.valid.gl.GLStringConstants.DASH));
+		DisequilibriumElement reference = new BaseDisequilibriumElement(refMap, "1", "note");
+
+		HashMap<Locus, List<String>> queryMap = new HashMap<Locus, List<String>>();
+		queryMap.put(Locus.HLA_DRB345, list("HLA-DRB3*01:01:02:01"));
+		MultiLocusHaplotype homozygousHaplotype = haplotype();
+		homozygousHaplotype.setDRB345Homozygous(true);
+		DisequilibriumElement query = new CoreDisequilibriumElement(queryMap, homozygousHaplotype);
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference));
+	}
+
+	@Test
+	public void testArsOnlyMatchAgreesWithBruteForce() throws IOException, InvalidFormatException {
+		// Finds a real example, from the actually-loaded ARS reference data, of a query allele
+		// that matches a reference allele *only* via ARS/G-group membership -- i.e. one with no
+		// field-level prefix overlap at all -- rather than hand-picking a specific allele pair
+		// that could quietly go stale as IMGT/HLA data changes. Skips (rather than fails) if none
+		// is found, since that would say more about data/network availability in this environment
+		// than about the index itself.
+		HashMap<String, HashSet<String>> arsMap = AntigenRecognitionSiteLoader.getInstance().getArsMap();
+
+		String referenceAllele = null;
+		String queryAllele = null;
+		outer:
+		for (Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+			for (String code : entry.getValue()) {
+				if (!org.dash.valid.gl.GLStringUtilities.fieldLevelComparison(code, entry.getKey())) {
+					referenceAllele = entry.getKey();
+					queryAllele = code;
+					break outer;
+				}
+			}
+		}
+
+		assumeTrue(referenceAllele != null, "Could not find a real ARS-only example pair in the loaded reference data");
+
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, referenceAllele);
+		DisequilibriumElement query = queryElement(Locus.HLA_A, queryAllele);
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference),
+				"query " + queryAllele + " should have matched " + referenceAllele + " via ARS membership");
+	}
+
+	@Test
+	public void testAgainstALargerMixedReferenceList() {
+		// A broader sanity check with more rows and more variety (matching, non-matching, and
+		// differing field counts at the same locus) than the single-row cases above, still
+		// verified against the same brute-force oracle rather than hand-asserted expectations.
+		List<DisequilibriumElement> elements = new ArrayList<DisequilibriumElement>();
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*01:01:01:01"));
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*02:01:01:01"));
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*03:01"));
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*01:02"));
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*11:01:01:01"));
+
+		assertIndexAgreesWithBruteForce(elements, queryElement(Locus.HLA_A, "HLA-A*01:01"));
+		assertIndexAgreesWithBruteForce(elements, queryElement(Locus.HLA_A, "HLA-A*03:01:01:01"));
+		assertIndexAgreesWithBruteForce(elements, queryElement(Locus.HLA_A, "HLA-A*24:02"));
+	}
+
+	private static void assertIndexAgreesWithBruteForce(List<DisequilibriumElement> elements, DisequilibriumElement query) {
+		List<DisequilibriumElement> indexed = DisequilibriumElementIndex.forElements(elements).findMatches(query);
+		List<DisequilibriumElement> bruteForce = bruteForceMatches(elements, query);
+
+		assertEquals(bruteForce, indexed,
+				"indexed lookup must find exactly the same matches, in the same order, as a plain linear equals() scan");
+	}
+
+	// The oracle: exactly what the old code was doing conceptually (find every element the query
+	// equals(), in list order) -- obviously correct by inspection, since it's just equals() called
+	// directly against every candidate with no indexing involved at all.
+	private static List<DisequilibriumElement> bruteForceMatches(List<DisequilibriumElement> elements, DisequilibriumElement query) {
+		List<DisequilibriumElement> matches = new ArrayList<DisequilibriumElement>();
+		for (DisequilibriumElement element : elements) {
+			if (query.equals(element)) {
+				matches.add(element);
+			}
+		}
+		return matches;
+	}
+
+	private static DisequilibriumElement referenceRow(Locus locus, String allele) {
+		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
+		hlaElementMap.put(locus, list(allele));
+		return new BaseDisequilibriumElement(hlaElementMap, "1", "note");
+	}
+
+	private static DisequilibriumElement queryElement(Locus locus, String allele) {
+		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
+		hlaElementMap.put(locus, list(allele));
+		return new CoreDisequilibriumElement(hlaElementMap, haplotype());
+	}
+
+	private static MultiLocusHaplotype haplotype() {
+		return new MultiLocusHaplotype(new java.util.concurrent.ConcurrentHashMap<Locus, List<String>>(), new HashMap<Locus, Integer>(), false);
+	}
+
+	private static List<String> list(String allele) {
+		List<String> alleles = new ArrayList<String>();
+		alleles.add(allele);
+		return alleles;
+	}
+}

--- a/ld-validation/src/test/java/org/dash/valid/ars/AntigenRecognitionSiteCacheTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/ars/AntigenRecognitionSiteCacheTest.java
@@ -1,0 +1,176 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.ars;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import org.dash.valid.gl.GLStringConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class AntigenRecognitionSiteCacheTest {
+
+	@TempDir
+	Path tempCacheDir;
+
+	@BeforeEach
+	public void pointCacheAtTempDir() {
+		System.setProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY, tempCacheDir.toString());
+	}
+
+	@AfterEach
+	public void clearOverride() {
+		System.clearProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY);
+	}
+
+	@Test
+	public void testMissingCacheFileIsAPlainMiss() {
+		assertNull(AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testWriteThenReadRoundTripsForAPinnedVersion() {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01", "HLA-A*01:02")));
+		arsMap.put("HLA-B*07:02g", new HashSet<String>(java.util.Arrays.asList("HLA-B*07:02")));
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		HashMap<String, HashSet<String>> read = AntigenRecognitionSiteCache.read("3.65.0");
+
+		assertEquals(arsMap, read);
+	}
+
+	@Test
+	public void testEmptyAlleleSetRoundTrips() {
+		// A gGroup with no gGroupAllele children -- the edge case where a naive "".split(",")
+		// would reconstruct a bogus single empty-string allele instead of a truly empty set.
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*99:99g", new HashSet<String>());
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		HashMap<String, HashSet<String>> read = AntigenRecognitionSiteCache.read("3.65.0");
+
+		assertEquals(arsMap, read);
+		assertTrue(read.get("HLA-A*99:99g").isEmpty());
+	}
+
+	@Test
+	public void testDifferentHladbVersionsDoNotCollide() {
+		HashMap<String, HashSet<String>> arsMapA = new HashMap<String, HashSet<String>>();
+		arsMapA.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		HashMap<String, HashSet<String>> arsMapB = new HashMap<String, HashSet<String>>();
+		arsMapB.put("HLA-B*07:02g", new HashSet<String>(java.util.Arrays.asList("HLA-B*07:02")));
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMapA);
+		AntigenRecognitionSiteCache.write("3.60.0", arsMapB);
+
+		assertEquals(arsMapA, AntigenRecognitionSiteCache.read("3.65.0"));
+		assertEquals(arsMapB, AntigenRecognitionSiteCache.read("3.60.0"));
+	}
+
+	@Test
+	public void testPinnedVersionNeverExpires() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile("3.65.0", arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.DAYS.toMillis(365));
+
+		// A year-old cache entry for a *pinned* version must still be honored -- the data can
+		// never have changed since IMGT/HLA published that specific release.
+		assertEquals(arsMap, AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testLatestExpiresAfterTtl() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.HOURS.toMillis(25));
+
+		// Latest is a moving branch, not a pinned release -- a 25-hour-old entry must be treated
+		// as stale, not served forever.
+		assertNull(AntigenRecognitionSiteCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testLatestWithinTtlIsStillHonored() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.HOURS.toMillis(1));
+
+		assertEquals(arsMap, AntigenRecognitionSiteCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testCorruptCacheFileIsATreatedAsAMiss() throws IOException {
+		File file = AntigenRecognitionSiteCache.cacheFile("3.65.0");
+		file.getParentFile().mkdirs();
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("not a cache file at all\njust garbage\n");
+		}
+
+		assertNull(AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testWriteIsBestEffortAndDoesNotThrowWhenDirectoryCannotBeCreated() throws IOException {
+		// Point the "cache directory" at a path that's actually a regular file -- Files#createDirectories
+		// will fail, and write() must swallow that rather than propagating it, since a cache
+		// write failing must never affect the correctness of a result the caller already has.
+		File notADirectory = tempCacheDir.resolve("actually-a-file").toFile();
+		try (FileWriter writer = new FileWriter(notADirectory)) {
+			writer.write("occupying this path");
+		}
+		System.setProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY, notADirectory.getAbsolutePath());
+
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>());
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		// No exception reaching here is the actual assertion.
+	}
+
+	private void writeRawCacheFile(String hladb, HashMap<String, HashSet<String>> arsMap, long cachedAtMillis) throws IOException {
+		File file = AntigenRecognitionSiteCache.cacheFile(hladb);
+		file.getParentFile().mkdirs();
+
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("#cachedAt=" + cachedAtMillis + "\n");
+			for (java.util.Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+				writer.write(entry.getKey() + "\t" + String.join(",", entry.getValue()) + "\n");
+			}
+		}
+	}
+}

--- a/ld-validation/src/test/java/org/dash/valid/cwd/CommonWellDocumentedCacheTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/cwd/CommonWellDocumentedCacheTest.java
@@ -1,0 +1,178 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.cwd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.dash.valid.gl.GLStringConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class CommonWellDocumentedCacheTest {
+
+	@TempDir
+	Path tempCacheDir;
+
+	@BeforeEach
+	public void pointCacheAtTempDir() {
+		System.setProperty(CommonWellDocumentedCache.CWD_CACHE_DIR_PROPERTY, tempCacheDir.toString());
+	}
+
+	@AfterEach
+	public void clearOverride() {
+		System.clearProperty(CommonWellDocumentedCache.CWD_CACHE_DIR_PROPERTY);
+	}
+
+	@Test
+	public void testMissingCacheFileIsAPlainMiss() {
+		assertNull(CommonWellDocumentedCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testWriteThenReadRoundTripsForAPinnedVersion() {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001", "HLA02169")));
+		accessionMap.put("HLA-B*07:02", new ArrayList<String>(Arrays.asList("HLA00654")));
+
+		CommonWellDocumentedCache.write("3.65.0", accessionMap);
+		HashMap<String, List<String>> read = CommonWellDocumentedCache.read("3.65.0");
+
+		assertEquals(accessionMap, read);
+	}
+
+	@Test
+	public void testOrderAndDuplicatesArePreserved() {
+		// Unlike the ARS cache's HashSet-valued map, accessions are a List -- order and
+		// duplicates are both meaningful and must round-trip exactly.
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00003", "HLA00001", "HLA00001")));
+
+		CommonWellDocumentedCache.write("3.65.0", accessionMap);
+		HashMap<String, List<String>> read = CommonWellDocumentedCache.read("3.65.0");
+
+		assertEquals(Arrays.asList("HLA00003", "HLA00001", "HLA00001"), read.get("HLA-A*01:01"));
+	}
+
+	@Test
+	public void testEmptyAccessionListRoundTrips() {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*99:99", new ArrayList<String>());
+
+		CommonWellDocumentedCache.write("3.65.0", accessionMap);
+		HashMap<String, List<String>> read = CommonWellDocumentedCache.read("3.65.0");
+
+		assertEquals(accessionMap, read);
+		assertTrue(read.get("HLA-A*99:99").isEmpty());
+	}
+
+	@Test
+	public void testNullKeyedEntryIsSkippedWithoutBreakingTheRestOfTheWrite() {
+		// Real-world regression: GLStringUtilities#convertToProteinLevel (whose result becomes
+		// the map key in loadFromIMGT) can return null for a malformed/short allele name --
+		// confirmed against actual hla.xml.zip data, not a hypothetical. Before this was handled,
+		// a null key threw inside the write loop, was swallowed by write()'s own catch, and
+		// silently left an orphaned, header-only .tmp file behind on *every* write -- meaning the
+		// cache was never actually populated at all, ever, for real data.
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001")));
+		accessionMap.put(null, new ArrayList<String>(Arrays.asList("HLA99999")));
+		accessionMap.put("HLA-B*07:02", new ArrayList<String>(Arrays.asList("HLA00654")));
+
+		CommonWellDocumentedCache.write("3.65.0", accessionMap);
+		HashMap<String, List<String>> read = CommonWellDocumentedCache.read("3.65.0");
+
+		assertEquals(Arrays.asList("HLA00001"), read.get("HLA-A*01:01"));
+		assertEquals(Arrays.asList("HLA00654"), read.get("HLA-B*07:02"));
+		assertEquals(2, read.size(), "the null-keyed entry should be dropped, not silently discard the whole write");
+
+		File[] leftoverTempFiles = tempCacheDir.toFile().listFiles((dir, name) -> name.endsWith(".tmp"));
+		assertTrue(leftoverTempFiles == null || leftoverTempFiles.length == 0, "a successful write must not leave an orphaned .tmp file behind");
+	}
+
+	@Test
+	public void testPinnedVersionNeverExpires() throws IOException {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001")));
+
+		writeRawCacheFile("3.65.0", accessionMap, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(365));
+
+		assertEquals(accessionMap, CommonWellDocumentedCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testLatestExpiresAfterTtl() throws IOException {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, accessionMap, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(25));
+
+		assertNull(CommonWellDocumentedCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testLatestWithinTtlIsStillHonored() throws IOException {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, accessionMap, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1));
+
+		assertEquals(accessionMap, CommonWellDocumentedCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testCorruptCacheFileIsTreatedAsAMiss() throws IOException {
+		File file = CommonWellDocumentedCache.cacheFile("3.65.0");
+		file.getParentFile().mkdirs();
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("not a cache file at all\njust garbage\n");
+		}
+
+		assertNull(CommonWellDocumentedCache.read("3.65.0"));
+	}
+
+	private void writeRawCacheFile(String hladb, HashMap<String, List<String>> accessionMap, long cachedAtMillis) throws IOException {
+		File file = CommonWellDocumentedCache.cacheFile(hladb);
+		file.getParentFile().mkdirs();
+
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("#cachedAt=" + cachedAtMillis + "\n");
+			for (Map.Entry<String, List<String>> entry : accessionMap.entrySet()) {
+				writer.write(entry.getKey() + "\t" + String.join(",", entry.getValue()) + "\n");
+			}
+		}
+	}
+}


### PR DESCRIPTION
Batched contribution from the fork (`mpresteg/ImmunogeneticDataTools`) — 6 fork PRs, 16 commits, no divergence from `master` (clean fast-forward, no conflicts).

## Docs (fork #29)

- Documented the browser UI (added in the prior Phase 8 batch) in `ld-service`'s README — it previously had zero mention despite being fully functional
- Added a root-README module overview linking each module's own README
- Fixed a broken `spring-boot:run` command in the docs (root cause: the aggregator POM itself inherits `spring-boot-starter-parent`, so a bare `plugin:goal` invocation runs against every project `-pl/-am` pulls in, including the non-runnable root aggregator) and moved dev-mode-only details to `CONTRIBUTING.md`, since `ld-service`'s own README should only describe what an end user needs

## Performance: a real user-reported slowdown, root-caused and fixed (fork #30, #31, #32)

Running `analyze-gl-strings` against a large (927K-row) custom frequency file took 60-150+ seconds *per genotype* — many hours extrapolated for a realistic input. Traced to `HLALinkageDisequilibrium`: a full `List#contains()`/`indexOf()` linear scan against the entire reference list, for every candidate haplotype a genotype's own ambiguity enumerates.

- `#30`: removed a redundant full-list copy made per candidate (real but insufficient on its own)
- `#31`: `DisequilibriumElementIndex` — a proper index respecting `DisequilibriumElement#equals()`'s fuzzy ARS/field-truncation matching semantics (a naive string-keyed map would have silently dropped real matches), verified via a differential test against a brute-force oracle plus the full existing regression suite passing unchanged
- `#32`: profiled #31 itself with `jstack`, found the index's own field-prefix buckets were too loose, tightened them

**Net result on the real reported case**: the original code's multi-hour trajectory → a full, verified-correct 337-genotype run completing in **22m53s**.

## Bootstrapping cost + a real 2017 correctness bug (fork #33, #34)

Investigated a separate, real complaint: a one-time ~80-130s cost fetching IMGT/HLA ARS reference data "seems long."

- `#33`: found network wasn't the bottleneck (a 40MB file downloads in ~2.6s) — the decompressed XML is 1.5GB/16.3M lines, 99.88% of which is content this loader never reads. Tried Woodstox's `skipElement()` to skip it — measured no improvement, since the tokenizer still has to scan past skipped content regardless. What did help: buffering the response before parsing, plus a local on-disk cache of the parsed result keyed by hladb version (permanent for pinned releases, a 24h TTL for the `Latest` moving branch).
- `#34`: while fixing this, found and reverted a real bug from 2017 (with a still-unresolved 2021 `TODO` on the same line) that silently zeroed out CWD-anomaly detection for every analysis using the default (`Latest`) hladb — i.e. anyone not explicitly passing `-v`. Verified via a byte-for-byte diff of a full real 337-genotype run: exactly one new, plausible finding, nothing else changed. Also caught and fixed a real bug in the new cache itself (a malformed real allele name producing a null map key silently broke every cache write) before merging, via testing against actual data rather than only unit tests.

**Net result on a pinned-hladb run**: cold 32.2s → warm 2.4s, output verified identical.

Each item above went through its own PR, review, and CI run on the fork; linking here for reference rather than re-describing every change in full. Full `mvn install` reactor build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)