### PR TITLE
Show software version in CLI --help and browser UI (closes #89)

### DIFF
--- a/ld-service/README.md
+++ b/ld-service/README.md
@@ -65,6 +65,10 @@ Interactive docs (springdoc-openapi) are served once the app is running:
 - Swagger UI: `http://localhost:8080/swagger-ui/index.html`
 - OpenAPI JSON: `http://localhost:8080/v3/api-docs`
 
+`GET /actuator/info` reports the running build's version (`{"build":{"name":"ld-service",
+"version":"1.0.0",...}}`) -- the browser UI's footer reads this to show its own version, the
+same idea as the CLI tools' `-h`/`-a` version display.
+
 ## Browser UI
 
 Once the app is running, open **`http://localhost:8080/`** for a browser UI covering the

--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -60,6 +60,17 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-web</artifactId>
       </dependency>
+      <!-- Backs the /actuator/info endpoint the browser UI's footer reads to show its own
+           version (issue #89's ask, applied to the UI as well as the CLI tools: see
+           ld-tools' About.java/-h fix for the CLI side). The "build" info contributor that
+           powers it auto-activates once build-info goal (below) generates a
+           META-INF/build-info.properties on the classpath; no separate config needed for that
+           part, just management.endpoints.web.exposure.include=info in application.properties
+           to expose it over HTTP (only "health" is exposed by default). -->
+      <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-actuator</artifactId>
+      </dependency>
       <!-- Replaces springfox-swagger2 (Phase 3b fix for a startup crash), now bumped from
            the javax/Boot-2.x line (springdoc-openapi-ui) to the jakarta/Boot-3.x
            successor. 2.9.0 is the latest 2.x release, tracked against Boot 3.x throughout
@@ -139,6 +150,16 @@
             <configuration>
               <mainClass>org.nmdp.validation.HLAHapVServiceApplication</mainClass>
             </configuration>
+          </execution>
+          <!-- Generates target/classes/META-INF/build-info.properties (artifact, group,
+               name, version, time), which Actuator's BuildInfoContributor picks up
+               automatically to populate /actuator/info's "build" section: just the
+               version for now, per issue #89. -->
+          <execution>
+            <id>build-info</id>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/ld-service/src/main/resources/application.properties
+++ b/ld-service/src/main/resources/application.properties
@@ -17,3 +17,10 @@ spring.servlet.multipart.max-request-size=-1
 # bodies before Spring's own multipart settings above are ever consulted. -1 disables it the same
 # way as the two settings above.
 server.tomcat.max-http-form-post-size=-1
+
+# Only "health" is exposed over HTTP by default; "info" is added so the browser UI's footer can
+# read /actuator/info (populated by the build-info Maven goal in pom.xml) to show its own
+# version, same rationale as ld-tools' -h/-a version display (issue #89). Same "personal/local
+# tool" scoping as the multipart settings above applies here too -- exposing build metadata
+# publicly isn't a concern for this deployment model.
+management.endpoints.web.exposure.include=info

--- a/ld-service/src/main/resources/static/css/app.css
+++ b/ld-service/src/main/resources/static/css/app.css
@@ -237,3 +237,10 @@ details pre {
   color: var(--muted);
   font-style: italic;
 }
+
+#app-version {
+  margin-top: 2rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-align: right;
+}

--- a/ld-service/src/main/resources/static/index.html
+++ b/ld-service/src/main/resources/static/index.html
@@ -79,6 +79,8 @@
   </section>
 </main>
 
+<footer id="app-version"></footer>
+
 <script src="/js/app.js"></script>
 </body>
 </html>

--- a/ld-service/src/main/resources/static/js/app.js
+++ b/ld-service/src/main/resources/static/js/app.js
@@ -310,4 +310,25 @@
     a.remove();
     URL.revokeObjectURL(url);
   });
+
+  // Best-effort: shows the running build's version in the footer, same rationale as the CLI
+  // tools' -h/-a version display (issue #89). Silently leaves the footer empty on any failure
+  // (endpoint disabled, network hiccup, unexpected response shape) rather than showing an error
+  // for something this cosmetic.
+  (function loadVersion() {
+    const footer = document.getElementById("app-version");
+    fetch("/actuator/info")
+      .then(function (response) {
+        return response.ok ? response.json() : null;
+      })
+      .then(function (info) {
+        const build = info && info.build;
+        if (build && build.name && build.version) {
+          footer.textContent = build.name + " " + build.version;
+        }
+      })
+      .catch(function () {
+        // Best-effort, see above.
+      });
+  })();
 })();

--- a/ld-service/src/test/java/org/nmdp/validation/StaticUiTest.java
+++ b/ld-service/src/test/java/org/nmdp/validation/StaticUiTest.java
@@ -22,8 +22,11 @@
 package org.nmdp.validation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -59,5 +62,20 @@ public class StaticUiTest {
         ResponseEntity<String> js = restTemplate.getForEntity("http://localhost:" + port + "/js/app.js", String.class);
         assertEquals(HttpStatus.OK, js.getStatusCode());
         assertTrue(js.getBody().contains("/genotypes/file"), "app.js should reference the async job endpoint it actually calls");
+        assertTrue(js.getBody().contains("/actuator/info"), "app.js should reference the version endpoint it reads for the footer");
+    }
+
+    // Issue #89, applied to the UI: real end-to-end coverage of the wiring, not just "the
+    // dependency is on the classpath" -- exercises the actual build-info Maven goal's output
+    // (target/classes/META-INF/build-info.properties) flowing through Actuator's real
+    // BuildInfoContributor and web exposure config, exactly what the browser footer depends on.
+    @Test
+    public void actuatorInfoEndpointReportsTheBuildVersion() throws Exception {
+        ResponseEntity<String> response = restTemplate.getForEntity("http://localhost:" + port + "/actuator/info", String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        JsonNode build = new ObjectMapper().readTree(response.getBody()).path("build");
+        assertEquals("ld-service", build.path("name").asText());
+        assertFalse(build.path("version").asText().isEmpty(), "build.version should be populated, not just present");
     }
 }

--- a/ld-tools/pom.xml
+++ b/ld-tools/pom.xml
@@ -39,6 +39,12 @@
     <maven.enforcer.maven-version>[3.0.4,)</maven.enforcer.maven-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.targetEncoding>UTF-8</project.build.targetEncoding>
+    <!-- ${maven.build.timestamp} itself is a special case Maven's own POM interpolator
+         resolves while parsing this file (that's why it works here), but it is not exposed to
+         templating-maven-plugin's later filter-sources step the same way: confirmed by
+         testing, and a known limitation (see e.g. MASSEMBLY-603 for the same issue in a
+         different plugin). Re-exposing it under a plain property name works around that. -->
+    <build.timestamp>${maven.build.timestamp}</build.timestamp>
   </properties>
     <dependencyManagement>
     <dependencies>
@@ -96,6 +102,38 @@
 
 <build>
     <plugins>
+      <!-- Populates the git.commit.id.abbrev and (built-in) maven.build.timestamp Maven
+           properties that About.java's java-template is filtered against below. Neither was
+           ever actually wired up before (issue #89): git.commit.id.abbrev in particular isn't a
+           built-in Maven property at all, so without this plugin it was always left as a
+           literal, unresolved "${git.commit.id.abbrev}" (formerly "${git.commit.id}") in every
+           build's about output (the "about" switch, short flag -a). Its "revision" goal defaults to the
+           initialize phase, which runs before templating-maven-plugin's generate-sources
+           filtering just below, so no explicit phase binding or plugin reordering is needed
+           here. Deliberately not configuring the git.dirty flag (a working-tree-is-dirty
+           indicator this plugin also offers); see the PR discussion for issue #89. -->
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>10.0.1</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- Default since plugin v4+: exports the abbreviated id as git.commit.id.abbrev
+               either way, but spelled out since About.java's comment refers to it by name. -->
+          <commitIdGenerationMode>flat</commitIdGenerationMode>
+          <!-- Only the Maven property is needed for template filtering; a git.properties
+               file in the built jar would be unused clutter. -->
+          <generateGitPropertiesFile>false</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>

--- a/ld-tools/src/main/java-templates/org/nmdp/validation/tools/About.java
+++ b/ld-tools/src/main/java-templates/org/nmdp/validation/tools/About.java
@@ -31,8 +31,17 @@ import java.io.PrintStream;
  */
 final class About {
     private static final String ARTIFACT_ID = "${project.artifactId}";
-    private static final String BUILD_TIMESTAMP = "${maven.build.timestamp}";
-    private static final String COMMIT = "${git.commit.id}";
+    // See ld-tools/pom.xml's build.timestamp property for why this isn't the more obvious
+    // "${maven.build.timestamp}" -- that placeholder is left unresolved by
+    // templating-maven-plugin's filtering step even though Maven's own POM parser resolves it
+    // fine inside pom.xml itself.
+    private static final String BUILD_TIMESTAMP = "${build.timestamp}";
+    // git-commit-id-maven-plugin's default commitIdGenerationMode ("flat") exports the
+    // abbreviated commit id as git.commit.id.abbrev -- there is no bare git.commit.id property
+    // in that mode (it's git.commit.id.full instead). Before the plugin was wired up
+    // (see ld-tools/pom.xml), this was "${git.commit.id}" and every build left it as a literal,
+    // unresolved placeholder: nothing in the build had ever defined that Maven property.
+    private static final String COMMIT = "${git.commit.id.abbrev}";
     private static final String COPYRIGHT = "Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)";
     private static final String LICENSE = "Licensed GNU Lesser General Public License (LGPL), version 3 or later";
     private static final String VERSION = "${project.version}";
@@ -120,5 +129,18 @@ final class About {
     public static void about(final PrintStream out) {
         checkNotNull(out);
         out.print(new About().toString());
+    }
+
+    /**
+     * Return a one-line "&lt;artifactId&gt; &lt;version&gt;" identifier, e.g. {@code ld-tools 1.0.0}.
+     * Used to show the software version alongside {@code --help} output, without repeating the
+     * full about block's commit/build/copyright/license lines there too (see
+     * https://github.com/nmdp-bioinformatics/ImmunogeneticDataTools/issues/89).
+     *
+     * @return the artifact id and version, space-separated
+     */
+    public static String header() {
+        About about = new About();
+        return about.artifactId() + " " + about.version();
     }
 }

--- a/ld-tools/src/main/java/org/nmdp/validation/tools/AnalyzeGLStrings.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/AnalyzeGLStrings.java
@@ -230,10 +230,10 @@ public class AnalyzeGLStrings implements Callable<Integer> {
                 System.exit(0);
             }
             if (help.wasFound()) {
-                Usage.usage(USAGE, null, commandLine, arguments, System.out);
+                Usage.usage(About.header(), USAGE, null, commandLine, arguments, System.out);
                 System.exit(0);
             }
-            
+
             analyzeGLStrings = new AnalyzeGLStrings(inputFile.getValue(), outputFile.getValue(), hladb.getValue(), freq.getValue(), warnings.getValue(), frequencyFiles.getValue(), allelesFile.getValue());
         }
         catch (CommandLineParseException | IllegalArgumentException e) {

--- a/ld-tools/src/main/java/org/nmdp/validation/tools/NormalizeFrequencyFile.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/NormalizeFrequencyFile.java
@@ -191,7 +191,7 @@ public class NormalizeFrequencyFile implements Callable<Integer> {
                 System.exit(0);
             }
             if (help.wasFound()) {
-                Usage.usage(USAGE, null, commandLine, arguments, System.out);
+                Usage.usage(About.header(), USAGE, null, commandLine, arguments, System.out);
                 System.exit(0);
             }
             normalizeFrequencyFile = new NormalizeFrequencyFile(inputFile.getValue(), frequencies.getValue(), outputFile.getValue());

--- a/ld-tools/src/main/java/org/nmdp/validation/tools/SyntheticGLStringGenerator.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/SyntheticGLStringGenerator.java
@@ -313,7 +313,7 @@ public class SyntheticGLStringGenerator implements Callable<Integer> {
                 System.exit(0);
             }
             if (help.wasFound()) {
-                Usage.usage(USAGE, null, commandLine, arguments, System.out);
+                Usage.usage(About.header(), USAGE, null, commandLine, arguments, System.out);
                 System.exit(0);
             }
             generator = new SyntheticGLStringGenerator(


### PR DESCRIPTION
## Summary

Closes #89 ("`analyze-gl-string -h` should tell the user the software version"). Two fork PRs, applied consistently across both the CLI and the browser UI since neither showed any version information before this:

### CLI (mpresteg/ImmunogeneticDataTools#35)

- `-h`/`--help` now prints a `ld-tools 1.0.0` header above the usage block, on all three `ld-tools` CLI tools (`analyze-gl-strings`, `normalize-frequency-file`, `synthetic-gl-string-generator`), via a new `About.header()` and `dsh-commandline`'s `Usage.usage(header, ...)` overload.
- Folded in a real, separate, much older bug found in the same file: `-a`/`--about`'s Commit/Build fields have printed the literal unresolved `${git.commit.id}` / `${maven.build.timestamp}` placeholders in every build since `About.java` was introduced in 2016 (`40d754e`) -- three years before #89 was filed, confirmed via `git log --follow`; just unwired boilerplate, not a prior attempt at #89. Fixed via `git-commit-id-maven-plugin` (abbreviated commit id, no dirty-tree flag) and a `build.timestamp` property workaround for `maven.build.timestamp` (a known limitation of `templating-maven-plugin`'s filtering, e.g. `MASSEMBLY-603` for the same issue elsewhere).

### Browser UI (mpresteg/ImmunogeneticDataTools#36)

- Same idea, extended to `ld-service`'s browser UI, which showed zero version information anywhere before this.
- Uses Spring Boot Actuator's `/actuator/info` endpoint (idiomatic for a Spring Boot app): `spring-boot-starter-actuator` + a `build-info` goal execution populate it, `management.endpoints.web.exposure.include=info` exposes it over HTTP.
- A small footer in the UI fetches it on load and shows `ld-service 1.0.0`, best-effort/silent on failure.
- Real end-to-end test coverage added (`StaticUiTest`), not just "the dependency is on the classpath."

## Verification

Both changes verified against real running builds (not just unit tests) -- see the individual fork PRs for full details:
- `analyze-gl-strings -a` / `-h` output confirmed against the actual built binary.
- `ld-service`'s `/actuator/info` and the UI footer confirmed against a real running jar and a real browser tab.

Full `ld-validation` + `ld-tools` + `ld-service` reactor test suite passes throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)