### PR TITLE
Cut peak heap in HLAFrequenciesLoader.loadStandardReferenceData

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/CoreDisequilibriumElement.java
+++ b/ld-validation/src/main/java/org/dash/valid/CoreDisequilibriumElement.java
@@ -1,7 +1,7 @@
 package org.dash.valid;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.dash.valid.gl.haplo.Haplotype;
 
@@ -19,7 +19,7 @@ public class CoreDisequilibriumElement extends DisequilibriumElement {
 	 * @param hlaElementMap this candidate's alleles, by locus
 	 * @param haplotype the haplotype this element represents
 	 */
-	public CoreDisequilibriumElement(HashMap<Locus, List<String>> hlaElementMap, Haplotype haplotype) {
+	public CoreDisequilibriumElement(Map<Locus, List<String>> hlaElementMap, Haplotype haplotype) {
 		setHlaElementMap(hlaElementMap);
 		setHaplotype(haplotype);
 	}

--- a/ld-validation/src/main/java/org/dash/valid/DisequilibriumElement.java
+++ b/ld-validation/src/main/java/org/dash/valid/DisequilibriumElement.java
@@ -22,8 +22,9 @@
 package org.dash.valid;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.dash.valid.gl.GLStringConstants;
@@ -58,13 +59,19 @@ public abstract class DisequilibriumElement {
 
 	public abstract String getFrequencyInfo();
 		
-	private HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
+	// EnumMap, not HashMap: this map is Locus-keyed, holds 2-9 entries, and a large custom
+	// reference file keeps millions of these resident at once (see
+	// HLAFrequenciesLoader#loadStandardReferenceData). An EnumMap is a pair of flat arrays
+	// sized to the enum rather than a Node[] table with per-entry Node objects. keySet()
+	// iteration is in Locus ordinal order; callers (Locus#lookup(Set), LinkagesLoader,
+	// DisequilibriumElementByRace marshalling) treat the locus set as unordered.
+	private Map<Locus, List<String>> hlaElementMap = new EnumMap<Locus, List<String>>(Locus.class);
 
 	public Collection<List<String>> getHlaElements() {
 		return hlaElementMap.values();
 	}
-	
-	public void setHlaElementMap(HashMap<Locus, List<String>> hlaElementMap) {
+
+	public void setHlaElementMap(Map<Locus, List<String>> hlaElementMap) {
 		this.hlaElementMap = hlaElementMap;
 	}
 	
@@ -76,7 +83,7 @@ public abstract class DisequilibriumElement {
 		return hlaElementMap.get(locus);
 	}
 	
-	public DisequilibriumElement(HashMap<Locus, List<String>> hlaElementMap) {
+	public DisequilibriumElement(Map<Locus, List<String>> hlaElementMap) {
 		this.hlaElementMap = hlaElementMap;
 	}
 	

--- a/ld-validation/src/main/java/org/dash/valid/base/BaseDisequilibriumElement.java
+++ b/ld-validation/src/main/java/org/dash/valid/base/BaseDisequilibriumElement.java
@@ -21,8 +21,8 @@
 */
 package org.dash.valid.base;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.dash.valid.CoreDisequilibriumElement;
 import org.dash.valid.Locus;
@@ -32,7 +32,7 @@ public class BaseDisequilibriumElement extends CoreDisequilibriumElement {
 	private String frequency;
 	private String note;
 	
-	public BaseDisequilibriumElement(HashMap<Locus, List<String>> hlaElementMap, String frequency, String note) {
+	public BaseDisequilibriumElement(Map<Locus, List<String>> hlaElementMap, String frequency, String note) {
 		setHlaElementMap(hlaElementMap);
 		setFrequency(frequency);
 		setNote(note);

--- a/ld-validation/src/main/java/org/dash/valid/freq/HLAFrequenciesLoader.java
+++ b/ld-validation/src/main/java/org/dash/valid/freq/HLAFrequenciesLoader.java
@@ -30,11 +30,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -423,66 +425,108 @@ public class HLAFrequenciesLoader {
 		return loadStandardReferenceData(reader);
 	}
 
+	// A real custom reference file (the NMDP nine-locus release: ~1 GB, ~6.4M rows, ~900K
+	// distinct haplotypes) has to be held entirely resident afterwards as DisequilibriumElement
+	// objects -- the detection engine does random-access per-genotype lookups against the whole
+	// set (see HLALinkageDisequilibrium / DisequilibriumElementIndex), so the resident set can't
+	// be streamed away. What this method controls is the *transient* overshoot on top of that
+	// resident set, and the per-element density of the resident set itself:
+	//   1. The pass-1 frequencyMap is drained entry-by-entry as pass 2 consumes it, instead of
+	//      being iterated by keySet() and left fully populated -- so the map's own Node+key
+	//      String garbage is reclaimable during pass 2 rather than only after it. The
+	//      List<FrequencyByRace> value stays reachable: it's aliased straight into the new
+	//      DisequilibriumElementByRace.
+	//   2. hlaElementMap is an EnumMap, not a HashMap -- for a 2-9 entry Locus-keyed map, held
+	//      millions of times over, that's a flat array instead of a Node[] table.
+	//   3. Each per-locus allele token and its (always singleton) List<String> are canonicalised
+	//      through a small cache: there are only a few hundred distinct alleles per locus but
+	//      millions of rows referencing them. The cached lists are immutable singletons
+	//      (nothing downstream mutates a reference row's allele list -- DisequilibriumElement
+	//      .equals(), DisequilibriumElementIndex and the report/Haplotype paths only ever read
+	//      them), so sharing one instance across every row that uses that token is safe.
+	//   4. Each CSV row is scanned with indexOf instead of String.split(",") -- 6.4M fewer
+	//      throwaway String[] + substring arrays feeding the GC churn that precedes the OOM.
+	// Measured on a 256 MB / 225K-distinct-haplotype synthetic nine-locus file: steady-state
+	// live heap ~800 MB -> ~445 MB, lowest completing -Xmx ~768m -> ~448m. The real release has
+	// more distinct alleles per locus (so #3 collapses less) and wider allele strings, so
+	// expect a smaller fraction there. Either way this does NOT bring a ~1 GB file under the
+	// 2 GB default heap; the -Xmx guidance in the READMEs stays necessary ("Memory / heap
+	// sizing" notes).
 	public static List<DisequilibriumElement> loadStandardReferenceData(
 			BufferedReader reader) throws IOException {
 		String row;
-		String[] columns;
 		HashMap<String, List<FrequencyByRace>> frequencyMap = new HashMap<String, List<FrequencyByRace>>();
-		
-		while ((row = reader.readLine()) != null) {			
-			columns = row.split(GLStringConstants.COMMA);
-						
-			String race = columns[0];
-			String haplotype = columns[1];
-			double frequency = Double.parseDouble(columns[2]);
-			String rank = null;
-			
-			if (columns.length == 4) rank = columns[3];
-			
+
+		while ((row = reader.readLine()) != null) {
+			// Standard format is race,haplotype,frequency[,rank]. The haplotype column is a
+			// "~"-joined allele string and never contains a comma, so a literal indexOf scan
+			// is a safe, allocation-free substitute for row.split(",").
+			int firstComma = row.indexOf(GLStringConstants.COMMA);
+			int secondComma = row.indexOf(GLStringConstants.COMMA, firstComma + 1);
+			int thirdComma = row.indexOf(GLStringConstants.COMMA, secondComma + 1);
+
+			String race = row.substring(0, firstComma);
+			String haplotype = row.substring(firstComma + 1, secondComma);
+			String frequencyText = thirdComma == -1
+					? row.substring(secondComma + 1)
+					: row.substring(secondComma + 1, thirdComma);
+			double frequency = Double.parseDouble(frequencyText);
+			// Matches the old row.split(",") behaviour: a bare trailing comma with nothing after
+			// it (a 3-field row) leaves rank null rather than "".
+			String rank = thirdComma == -1 || thirdComma == row.length() - 1
+					? null
+					: row.substring(thirdComma + 1);
+
 			List<FrequencyByRace> freqList = frequencyMap.get(haplotype);
-			
+
 			if (freqList == null) {
 				freqList = new ArrayList<FrequencyByRace>();
+				frequencyMap.put(haplotype, freqList);
 			}
-			
-			FrequencyByRace freqByRace = new FrequencyByRace(frequency, rank, race);
-			freqList.add(freqByRace);
-			
-			frequencyMap.put(haplotype, freqList);
+
+			freqList.add(new FrequencyByRace(frequency, rank, race));
 		}
-		
-		List<DisequilibriumElement> disequilibriumElements = new ArrayList<DisequilibriumElement>();
-		DisequilibriumElementByRace disElement;
+
+		reader.close();
+
+		List<DisequilibriumElement> disequilibriumElements = new ArrayList<DisequilibriumElement>(frequencyMap.size());
 		HashMap<String, Locus> locusMap = new HashMap<String, Locus>();
-		Locus locus = null;
-		
-		for (String haplotype : frequencyMap.keySet()) {
-			String[] locusHaplotypes = haplotype.split(GLStringConstants.GENE_PHASE_DELIMITER);
-			
-			HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
+		// token (e.g. "HLA-A*01:01") -> the shared immutable singleton list stored on every row
+		// that carries that allele at that locus.
+		HashMap<String, List<String>> canonicalAlleleLists = new HashMap<String, List<String>>();
+
+		Iterator<Map.Entry<String, List<FrequencyByRace>>> entries = frequencyMap.entrySet().iterator();
+		while (entries.hasNext()) {
+			Map.Entry<String, List<FrequencyByRace>> entry = entries.next();
+			String[] locusHaplotypes = entry.getKey().split(GLStringConstants.GENE_PHASE_DELIMITER);
+
+			EnumMap<Locus, List<String>> hlaElementMap = new EnumMap<Locus, List<String>>(Locus.class);
 			for (String locusHaplotype : locusHaplotypes) {
-				String[] parts = locusHaplotype.split(GLStringUtilities.ESCAPED_ASTERISK);
-				List<String> val = new ArrayList<String>();
-				val.add(locusHaplotype);
-				
-				if (locusMap.containsKey(parts[0])) {
-					locus = locusMap.get(parts[0]);
+				int asterisk = locusHaplotype.indexOf(GLStringConstants.ASTERISK);
+				String locusToken = asterisk == -1 ? locusHaplotype : locusHaplotype.substring(0, asterisk);
+
+				Locus locus = locusMap.get(locusToken);
+				if (locus == null) {
+					locus = Locus.normalizeLocus(Locus.lookup(locusToken));
+					locusMap.put(locusToken, locus);
 				}
-				else {
-					locus = Locus.normalizeLocus(Locus.lookup(parts[0]));
-					locusMap.put(parts[0], locus);
+
+				List<String> val = canonicalAlleleLists.get(locusHaplotype);
+				if (val == null) {
+					val = Collections.singletonList(locusHaplotype);
+					canonicalAlleleLists.put(locusHaplotype, val);
 				}
-				
+
 				hlaElementMap.put(locus, val);
 			}
-			
-			disElement = new DisequilibriumElementByRace(hlaElementMap, frequencyMap.get(haplotype));
-			
-			disequilibriumElements.add(disElement);			
+
+			disequilibriumElements.add(new DisequilibriumElementByRace(hlaElementMap, entry.getValue()));
+
+			// Drop the map's Node + key String now that its value list is aliased into the new
+			// element -- so pass-1 garbage is collectable mid-pass-2, not only after it.
+			entries.remove();
 		}
-		
-		reader.close();
-		
+
 		return disequilibriumElements;
 	}
 	

--- a/ld-validation/src/main/java/org/dash/valid/race/DisequilibriumElementByRace.java
+++ b/ld-validation/src/main/java/org/dash/valid/race/DisequilibriumElementByRace.java
@@ -22,8 +22,8 @@
 package org.dash.valid.race;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.dash.valid.CoreDisequilibriumElement;
 import org.dash.valid.Locus;
@@ -40,7 +40,7 @@ public class DisequilibriumElementByRace extends CoreDisequilibriumElement {
 		super();
 	}
 	
-	public DisequilibriumElementByRace (HashMap<Locus, List<String>> hlaElementMap, List<FrequencyByRace> frequenciesByRace) {
+	public DisequilibriumElementByRace (Map<Locus, List<String>> hlaElementMap, List<FrequencyByRace> frequenciesByRace) {
 		setHlaElementMap(hlaElementMap);
 		setFrequenciesByRace(frequenciesByRace);
 	}

--- a/ld-validation/src/test/java/org/dash/valid/HLAFrequenciesLoaderTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/HLAFrequenciesLoaderTest.java
@@ -22,9 +22,14 @@
 */
 package org.dash.valid;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.StringReader;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
@@ -77,5 +82,44 @@ public class HLAFrequenciesLoaderTest {
 
 		List<DisequilibriumElement> disElements = HLAFrequenciesLoader.getInstance(dpa1Dpb1Freqs, null).getDisequilibriumElements(Locus.DPA1_DPB1_LOCI);
 		assertTrue(disElements != null && disElements.size() > 0);
+	}
+
+	// Heap-footprint optimization (perf/large-frequency-file-heap): a real custom reference
+	// file (the NMDP nine-locus release: ~6.4M rows, ~900K distinct haplotypes) has to stay
+	// fully resident afterwards, so loadStandardReferenceData collapses each repeated per-locus
+	// allele token onto ONE shared, immutable singleton list rather than allocating a fresh
+	// ArrayList per row per locus. This is only safe because nothing downstream mutates a
+	// reference row's allele list. This test locks in both halves of that: the sharing (a
+	// regression that went back to per-row lists would still pass every other test, just use
+	// more heap) and the immutability contract that makes the sharing safe.
+	@Test
+	public void testReferenceRowsShareImmutableCanonicalAlleleLists() throws Exception {
+		String data =
+				"AFA,HLA-C*07:01~HLA-B*08:01,0.0100000000,1\n" +
+				"CAU,HLA-C*07:01~HLA-B*07:02,0.0200000000\n"; // second row deliberately has no rank column
+		List<DisequilibriumElement> elements =
+				HLAFrequenciesLoader.loadStandardReferenceData(new BufferedReader(new StringReader(data)));
+
+		assertEquals(2, elements.size());
+
+		List<String> firstRowC = null;
+		List<String> secondRowC = null;
+		for (DisequilibriumElement element : elements) {
+			List<String> c = element.getHlaElement(Locus.HLA_C);
+			assertEquals(1, c.size());
+			assertEquals("HLA-C*07:01", c.get(0));
+			if (firstRowC == null) {
+				firstRowC = c;
+			}
+			else {
+				secondRowC = c;
+			}
+		}
+
+		// Both rows carry HLA-C*07:01 -- they must hand back the very same list instance.
+		assertSame(firstRowC, secondRowC);
+		// And that shared instance must not be mutable, or one row's edit would corrupt the other.
+		final List<String> shared = firstRowC;
+		assertThrows(UnsupportedOperationException.class, () -> shared.set(0, "HLA-C*99:99"));
 	}
 }


### PR DESCRIPTION
## What

Deferred, optional follow-up to the large-frequency-file OOM (the immediate fix -- heap-sizing docs + ld-service `-Xmx` bump -- already shipped in #143). Scoped to `loadStandardReferenceData(BufferedReader)` plus the supporting `HashMap`->`Map` widening on the `DisequilibriumElement` hierarchy.

`analyze-gl-strings -q <large standard-format file>` and the ld-service `POST /genotypes/file` upload both route through this method. On the NMDP nine-locus release (~1 GB, ~6.4M rows, ~900K distinct haplotypes) it throws `OutOfMemoryError` at the `locusHaplotype.split(...)` in the second pass.

The detection engine needs the whole reference set resident as `DisequilibriumElement` objects for per-genotype random-access lookup, so **the resident set itself cannot be streamed away and this does not remove the need for `-Xmx` tuning** -- the README notes stay necessary and are untouched. What this trims is the transient overshoot during load and the per-element density of the resident set.

## Changes (all behaviour-preserving)

1. **Drain `frequencyMap` during pass 2** -- iterate an explicit `entrySet()` iterator and `remove()` each entry once its value list is aliased into the new element, instead of iterating `keySet()` with the map still fully populated. Both structures were live at peak before.
2. **`EnumMap<Locus, List<String>>`** instead of `HashMap` for the per-element `hlaElementMap`. Constructor/setter signatures widened `HashMap` -> `Map`; all existing `HashMap` callers still compile. `keySet()` iteration becomes Locus-ordinal order; every consumer treats the locus set as unordered (`Locus.lookup(Set)` uses `containsAll` both ways).
3. **Canonicalise repeated strings** -- per-locus allele token + its singleton `List<String>` collapse to one shared `Collections.singletonList` per token via a per-load cache. Safe: nothing downstream mutates a reference row's allele list; the list is immutable so an accidental future mutation fails loudly.
4. **`indexOf` row scan** instead of `String.split(",")` -- fewer throwaway arrays feeding the pre-OOM GC churn. Trailing-comma / no-rank rows keep the old null-rank behaviour.

## Measurements

Reproduced scaled-down (8 GB host): 256 MB / 225K-distinct synthetic nine-locus file, `analyze-gl-strings` on a homozygous nine-locus genotype.

| | before | after |
|---|---|---|
| steady-state live heap (`-Xmx1g`) | ~800 MB | ~445 MB |
| lowest completing `-Xmx` (marginal) | ~768m | ~448m |
| OOMs at | `-Xmx512m` | `-Xmx384m` |

`summary.xml` (and `detectedFindings.csv` / `haplotypePairs.log`) byte-identical before/after; the correct nine-locus `<haplo-pair>` is still detected. Full reactor suite green (`mvn package`).

The real release has more distinct alleles per locus (#3 collapses less) and wider allele strings, so expect a smaller fraction there.

## Tests

- New `HLAFrequenciesLoaderTest.testReferenceRowsShareImmutableCanonicalAlleleLists` locks in #3's observable contract (shared instance + immutability) -- a regression back to per-row lists would pass every other test.
- A forked tight-heap regression test was evaluated and **skipped**: the discriminating `-Xmx` band for a CI-sized file is only ~320-384m wide, too narrow to be stable across machines/JVMs. Measurements recorded here instead.

Originally landed on the fork as [mpresteg/ImmunogeneticDataTools#40](https://github.com/mpresteg/ImmunogeneticDataTools/pull/40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)